### PR TITLE
Use double layer of const for deserialize

### DIFF
--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -129,7 +129,7 @@ int scitoken_serialize(const SciToken token, char **value, char **err_msg) {
     return 0;
 }
 
-int scitoken_deserialize(const char *value, SciToken *token, const char **allowed_issuers, char **err_msg) {
+int scitoken_deserialize(const char *value, SciToken *token, char const* const* allowed_issuers, char **err_msg) {
     if (value == nullptr) {
         if (err_msg) {*err_msg = strdup("Token may not be NULL");}
         return -1;

--- a/src/scitokens.h
+++ b/src/scitokens.h
@@ -38,7 +38,7 @@ void scitoken_set_lifetime(SciToken token, int lifetime);
 
 int scitoken_serialize(const SciToken token, char **value, char **err_msg);
 
-int scitoken_deserialize(const char *value, SciToken *token, const char **allowed_issuers, char **err_msg);
+int scitoken_deserialize(const char *value, SciToken *token, char const* const* allowed_issuers, char **err_msg);
 
 Validator validator_create();
 


### PR DESCRIPTION
Using `const char**` does not allow implicit conversion from `char**`.  It has to be protected at both level of de-reference:  `char const* const*`