### PR TITLE
Fix build failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,14 +31,18 @@ elseif( UNIX )
 
 include (FindPkgConfig)
 pkg_check_modules(LIBCRYPTO REQUIRED libcrypto)
+pkg_check_modules(OPENSSL REQUIRED openssl)
 pkg_check_modules(SQLITE REQUIRED sqlite3)
 
+# pkg_check_modules fails to return an absolute path on RHEL7.  Set the
+# link directories accordingly.
+link_directories(${OPENSSL_LIBRARY_DIRS} ${LIBCRYPTO_LIBRARY_DIRS})
 endif()
 
-include_directories( "${PROJECT_SOURCE_DIR}" ${JWT_CPP_INCLUDES} ${CURL_INCLUDES} ${LIBCRYPTO_INCLUDE_DIRS} ${SQLITE_INCLUDE_DIRS}  ${UUID_INCLUDE_DIRS} )
+include_directories( "${PROJECT_SOURCE_DIR}" ${JWT_CPP_INCLUDES} ${CURL_INCLUDES} ${OPENSSL_INCLUDE_DIRS} ${LIBCRYPTO_INCLUDE_DIRS} ${SQLITE_INCLUDE_DIRS}  ${UUID_INCLUDE_DIRS} )
 
 add_library(SciTokens SHARED src/scitokens.cpp src/scitokens_internal.cpp src/scitokens_cache.cpp)
-target_link_libraries(SciTokens ${LIBCRYPTO_LIBRARIES} ${CURL_LIBRARIES} ${SQLITE_LIBRARIES} ${UUID_LIBRARIES})
+target_link_libraries(SciTokens ${OPENSSL_LIBRARIES} ${LIBCRYPTO_LIBRARIES} ${CURL_LIBRARIES} ${SQLITE_LIBRARIES} ${UUID_LIBRARIES})
 
 if ( NOT APPLE AND UNIX )
 set_target_properties(SciTokens PROPERTIES LINK_FLAGS "-Wl,--version-script=${PROJECT_SOURCE_DIR}/configs/export-symbols")

--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -216,7 +216,7 @@ int validator_validate(Validator validator, SciToken scitoken, char **err_msg) {
 
     try {
         real_validator->verify(*real_scitoken);
-    } catch (std::exception exc) {
+    } catch (std::exception &exc) {
         if (err_msg) {*err_msg = strdup(exc.what());}
         return -1;
     }

--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -304,11 +304,6 @@ normalize_absolute_path(const std::string &path) {
 }
 
 
-int empty_validator(const char *, char **) {
-    return 0;
-}
-
-
 }
 
 

--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -238,9 +238,13 @@ rs256_from_coords(const std::string &e_str, const std::string &n_str) {
     std::unique_ptr<BIGNUM, decltype(&BN_free)> n_bignum(BN_bin2bn(reinterpret_cast<const unsigned char *>(n_decode.c_str()), n_decode.size(), nullptr), BN_free);
 
     std::unique_ptr<RSA, decltype(&RSA_free)> rsa(RSA_new(), RSA_free);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     rsa->e = e_bignum.get();
     rsa->n = n_bignum.get();
     rsa->d = nullptr;
+#else
+    RSA_set0_key(rsa.get(), n_bignum.get(), e_bignum.get(), nullptr);
+#endif
     e_bignum.release();
     n_bignum.release();
 

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -384,7 +384,7 @@ public:
         try {
             m_validator.verify(scitoken);
             return true;
-        } catch (std::runtime_error) {
+        } catch (std::runtime_error &) {
             return false;
         }
     }


### PR DESCRIPTION
Fixes:
- Warnings due to an unused static function.
- Passing polymorphic exceptions by value.
- OpenSSL 1.1 API changes.