### PR TITLE
Fix compiler errors for system debian stretch g++ 6.3

### DIFF
--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -56,7 +56,7 @@ int scitoken_set_claim_string(SciToken token, const char *key, const char *value
         return -1;
     }
     try {
-        real_token->set_claim(key, std::string(value));
+        real_token->set_claim(key, jwt::claim(std::string(value)));
     } catch (std::exception &exc) {
         if (err_msg) {
             *err_msg = strdup(exc.what());

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -160,7 +160,7 @@ public:
         uuid_generate(uuid);
         char uuid_str[37];
         uuid_unparse_lower(uuid, uuid_str);
-        m_claims["jti"] = std::string(uuid_str);
+        m_claims["jti"] = jwt::claim(std::string(uuid_str));
 
         // Set all the payload claims
         for (auto it : m_claims) {


### PR DESCRIPTION
I was not able to compile this on debian stretch with system g++ (Debian 6.3.0-18+deb9u1) 6.3.0 20170516 until I created the jwt::claim explicitly.

> In file included from /tmp/scitokens-cpp/src/scitokens.cpp:7:0:
/tmp/scitokens-cpp/src/scitokens_internal.h: In member function ‘std::__cxx11::string scitokens::SciToken::serialize()’:
/tmp/scitokens-cpp/src/scitokens_internal.h:163:47: error: no match for ‘operator=’ (operand types are ‘std::unordered_map<std::__cxx11::basic_string<char>, jwt::claim>::mapped_type {aka jwt::claim}’ and ‘std::__cxx11::string {aka std::__cxx11::basic_string<char>}’)
         m_claims["jti"] = std::string(uuid_str);
                                               ^
In file included from /tmp/scitokens-cpp/src/scitokens_internal.h:6:0,
                 from /tmp/scitokens-cpp/src/scitokens.cpp:7:
/usr/include/jwt-cpp/jwt.h:750:8: note: candidate: jwt::claim& jwt::claim::operator=(const jwt::claim&)
  class claim {
        ^~~~~
/usr/include/jwt-cpp/jwt.h:750:8: note:   no known conversion for argument 1 from ‘std::__cxx11::string {aka std::__cxx11::basic_string<char>}’ to ‘const jwt::claim&’
/usr/include/jwt-cpp/jwt.h:750:8: note: candidate: jwt::claim& jwt::claim::operator=(jwt::claim&&)
/usr/include/jwt-cpp/jwt.h:750:8: note:   no known conversion for argument 1 from ‘std::__cxx11::string {aka std::__cxx11::basic_string<char>}’ to ‘jwt::claim&&’
/tmp/scitokens-cpp/src/scitokens.cpp: In function ‘int scitoken_set_claim_string(SciToken, const char*, const char*, char**)’:
/tmp/scitokens-cpp/src/scitokens.cpp:59:54: error: no matching function for call to ‘scitokens::SciToken::set_claim(const char*&, std::__cxx11::string)’
         real_token->set_claim(key, std::string(value));
                                                      ^
In file included from /tmp/scitokens-cpp/src/scitokens.cpp:7:0:
/tmp/scitokens-cpp/src/scitokens_internal.h:119:5: note: candidate: void scitokens::SciToken::set_claim(const string&, const jwt::claim&)
     set_claim(const std::string &key, const jwt::claim &value) {
     ^~~~~~~~~
/tmp/scitokens-cpp/src/scitokens_internal.h:119:5: note:   no known conversion for argument 2 from ‘std::__cxx11::string {aka std::__cxx11::basic_string<char>}’ to ‘const jwt::claim&’
