### PR TITLE
Add support for the WLCG profile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package( OpenSSL REQUIRED )
 find_package( Sqlite3 REQUIRED )
 set(LIBCRYPTO_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
 set(LIBCRYPTO_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY})
+set(CMAKE_MACOSX_RPATH ON)
 
 elseif( UNIX )
 
@@ -59,6 +60,9 @@ target_link_libraries(scitokens-test-access SciTokens)
 
 add_executable(scitokens-list-access src/list_access.cpp)
 target_link_libraries(scitokens-list-access SciTokens)
+
+add_executable(scitokens-create src/create.cpp)
+target_link_libraries(scitokens-create SciTokens)
 
 if (NOT DEFINED LIB_INSTALL_DIR)
   SET(LIB_INSTALL_DIR "lib")

--- a/src/create.cpp
+++ b/src/create.cpp
@@ -1,0 +1,198 @@
+
+#include "scitokens.h"
+
+#include <stdlib.h>
+#include <getopt.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+#include <fstream>
+
+namespace {
+
+const char usage[] = \
+"\n"
+"Syntax: %s [--cred cred_file] [--key key_file] [--keyid kid]\n"
+"           [--claim key=val] ...\n"
+"\n"
+" Options\n"
+"    -h | --help                        Display usage\n"
+"    -c | --cred           <cred_file>  File containing signing credential.\n"
+"    -k | --key             <key_file>  File containing the signing private key.\n"
+"    -K | --keyid                <kid>  Name of the token key.\n"
+"    -i | --issuer            <issuer>  Issuer for the token.\n"
+"    -p | --profile          <profile>  Token profile (wlcg, scitokens1, scitokens2).\n"
+"\n";
+
+const struct option long_options[] =
+{
+    {"help",           no_argument, NULL, 'h'},
+    {"cred",     required_argument, NULL, 'c'},
+    {"key",      required_argument, NULL, 'k'},
+    {"keyid",    required_argument, NULL, 'K'},
+    {"issuer",   required_argument, NULL, 'i'},
+    {"claim",    required_argument, NULL, 'C'},
+    {"profile",  required_argument, NULL, 'p'},
+    {0, 0, 0, 0}
+};
+
+const char short_options[] = "hc:k:K:i:C:p:";
+
+std::string g_cred, g_key, g_kid, g_issuer, g_profile;
+std::vector<std::string> g_claims;
+
+int init_arguments(int argc, char *argv[]) {
+
+    int arg;
+    while((arg = getopt_long(argc, argv, short_options, long_options, nullptr)) != -1)
+    {
+        switch (arg)
+        {
+        case 'h':
+            printf(usage, argv[0]);
+            exit(0);
+            break;
+        case 'c':
+            g_cred = optarg;
+            break;
+        case 'k':
+            g_key = optarg;
+            break;
+        case 'K':
+            g_kid = optarg;
+            break;
+        case 'i':
+            g_issuer = optarg;
+            break;
+        case 'C':
+            g_claims.emplace_back(optarg);
+            break;
+        case 'p':
+            g_profile = optarg;
+            break;
+        default:
+            fprintf(stderr, usage, argv[0]);
+            exit(1);
+            break;
+        }
+    }
+
+    if (optind != argc) {
+        fprintf(stderr, "%s: invalid option -- %s\n", argv[0], argv[optind]);
+        fprintf(stderr, usage, argv[0]);
+        exit(1);
+    }
+
+    if (g_cred.empty()) {
+        fprintf(stderr, "%s: missing --cred option\n", argv[0]);
+        fprintf(stderr, usage, argv[0]);
+        exit(1);
+    }
+
+    if (g_key.empty()) {
+        fprintf(stderr, "%s: missing --key option\n", argv[0]);
+        fprintf(stderr, usage, argv[0]);
+        exit(1);
+    }
+
+    if (g_kid.empty()) {
+        fprintf(stderr, "%s: missing --keyid option\n", argv[0]);
+        fprintf(stderr, usage, argv[0]);
+        exit(1);
+    }
+
+    if (g_issuer.empty()) {
+        fprintf(stderr, "%s: missing --issuer option\n", argv[0]);
+        fprintf(stderr, usage, argv[0]);
+        exit(1);
+    }
+
+    return 0;
+}
+
+}
+
+int main(int argc, char *argv[]) {
+
+    int rv = init_arguments(argc, argv);
+    if (rv) {
+        return rv;
+    }
+
+    std::ifstream priv_ifs(g_key);
+    std::string private_contents( (std::istreambuf_iterator<char>(priv_ifs)),
+                          (std::istreambuf_iterator<char>())
+                        );
+    std::ifstream pub_ifs(g_cred);
+    std::string public_contents( (std::istreambuf_iterator<char>(pub_ifs)),
+                          (std::istreambuf_iterator<char>())
+                        );
+
+    char *err_msg;
+    auto key_raw = scitoken_key_create(g_kid.c_str(), "ES256", public_contents.c_str(),
+                                       private_contents.c_str(), &err_msg);
+    std::unique_ptr<void, decltype(&scitoken_key_destroy)>
+            key(key_raw, scitoken_key_destroy);
+    if (key_raw == nullptr) {
+        fprintf(stderr, "Failed to generate a key: %s\n", err_msg);
+        free(err_msg);
+        return 1;
+    }
+
+    std::unique_ptr<void, decltype(&scitoken_destroy)>
+        token(scitoken_create(key_raw), scitoken_destroy);
+    if (token.get() == nullptr) {
+        fprintf(stderr, "Failed to generate a new token.\n");
+        return 1;
+    }
+
+    rv = scitoken_set_claim_string(token.get(), "iss", g_issuer.c_str(), &err_msg);
+    if (rv) {
+        fprintf(stderr, "Failed to set issuer: %s\n", err_msg);
+        free(err_msg);
+        return 1;
+    }
+
+    for (const auto &claim : g_claims) {
+        auto pos = claim.find("=");
+        if (pos == std::string::npos) {
+            fprintf(stderr, "Claim must contain a '=' character: %s\n", claim.c_str());
+            return 1;
+        }
+        auto key = claim.substr(0, pos);
+        auto val = claim.substr(pos + 1);
+
+        rv = scitoken_set_claim_string(token.get(), key.c_str(), val.c_str(), &err_msg);
+        if (rv) {
+            fprintf(stderr, "Failed to set claim (%s=%s): %s\n", key.c_str(), val.c_str(), err_msg);
+            free(err_msg);
+            return 1;
+        }
+    }
+
+    if (!g_profile.empty()) {
+        SciTokenProfile profile;
+        if (g_profile == "wlcg") {
+            profile = SciTokenProfile::WLCG_1_0;
+        } else if (g_profile == "scitokens1") {
+            profile = SciTokenProfile::SCITOKENS_1_0;
+        } else if (g_profile == "scitokens2") {
+            profile = SciTokenProfile::SCITOKENS_2_0;
+        } else {
+            fprintf(stderr, "Unknown token profile: %s\n", g_profile.c_str());
+            return 1;
+        }
+        scitoken_set_serialize_mode(token.get(), profile);
+    }
+
+    char *value;
+    rv = scitoken_serialize(token.get(), &value, &err_msg);
+    if (rv) {
+        fprintf(stderr, "Failed to serialize the token: %s\n", err_msg);
+        free(err_msg);
+        return 1;
+    }
+
+    printf("%s\n", value);
+}

--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -169,6 +169,21 @@ int scitoken_deserialize(const char *value, SciToken *token, char const* const* 
     return 0;
 }
 
+int scitoken_store_public_ec_key(const char *issuer, const char *keyid, const char *key, char **err_msg)
+{
+    bool success;
+    try {
+        success = scitokens::Validator::store_public_ec_key(issuer, keyid, key);
+    } catch (std::exception &exc) {
+        if (err_msg) {
+            *err_msg = strdup(exc.what());
+        }
+        return -1;
+    }
+
+    return success ? 0 : -1;
+}
+
 Validator validator_create() {
     return new Validator();
 }

--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -189,6 +189,13 @@ Validator validator_create() {
 }
 
 
+void validator_destroy(Validator validator) {
+    scitokens::Validator *real_validator =
+        reinterpret_cast<scitokens::Validator*>(validator);
+    delete real_validator;
+}
+
+
 void validator_set_token_profile(Validator validator, SciTokenProfile profile) {
     if (validator == nullptr) {return;}
     auto real_validator = reinterpret_cast<scitokens::Validator*>(validator);

--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -67,6 +67,14 @@ int scitoken_set_claim_string(SciToken token, const char *key, const char *value
 }
 
 
+void scitoken_set_serialize_mode(SciToken token, SciTokenProfile profile) {
+    scitokens::SciToken *real_token = reinterpret_cast<scitokens::SciToken*>(token);
+    if (real_token == nullptr) {return;}
+
+    real_token->set_serialize_mode(static_cast<scitokens::SciToken::Profile>(profile));
+}
+
+
 int scitoken_get_claim_string(const SciToken token, const char *key, char **value, char **err_msg) {
     scitokens::SciToken *real_token = reinterpret_cast<scitokens::SciToken*>(token);
     std::string claim_str;
@@ -165,6 +173,13 @@ Validator validator_create() {
     return new Validator();
 }
 
+
+void validator_set_token_profile(Validator validator, SciTokenProfile profile) {
+    if (validator == nullptr) {return;}
+    auto real_validator = reinterpret_cast<scitokens::Validator*>(validator);
+    real_validator->set_validate_profile(static_cast<scitokens::SciToken::Profile>(profile));
+}
+
 int validator_add(Validator validator, const char *claim, StringValidatorFunction validator_func, char **err_msg) {
     if (validator == nullptr) {
         if (err_msg) {*err_msg = strdup("Validator may not be a null pointer");}
@@ -254,6 +269,14 @@ void enforcer_acl_free(Acl *acls) {
         free(const_cast<char *>(acls[idx].resource));
     }
     free(acls);
+}
+
+
+void enforcer_set_validate_profile(Enforcer enf, SciTokenProfile profile) {
+    if (enf == nullptr) {return;}
+
+    auto real_enf = reinterpret_cast<scitokens::Enforcer*>(enf);
+    real_enf->set_validate_profile(static_cast<scitokens::SciToken::Profile>(profile));
 }
 
 

--- a/src/scitokens.h
+++ b/src/scitokens.h
@@ -77,6 +77,11 @@ int validator_add_critical_claims(Validator validator, const char **claims, char
 
 int validator_validate(Validator validator, SciToken scitoken, char **err_msg);
 
+/**
+ * Destroy a validator object.
+ */
+void validator_destroy(Validator);
+
 Enforcer enforcer_create(const char *issuer, const char **audience, char **err_msg);
 
 void enforcer_destroy(Enforcer);

--- a/src/scitokens.h
+++ b/src/scitokens.h
@@ -61,6 +61,8 @@ void scitoken_set_serialize_mode(SciToken token, SciTokenProfile profile);
 
 int scitoken_deserialize(const char *value, SciToken *token, char const* const* allowed_issuers, char **err_msg);
 
+int scitoken_store_public_ec_key(const char *issuer, const char *keyid, const char *value, char **err_msg);
+
 Validator validator_create();
 
 /**

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -27,7 +27,7 @@ public:
 class MissingIssuerException : public std::runtime_error {
 public:
     MissingIssuerException()
-        : std::runtime_error("Issuer not specific in claims")
+        : std::runtime_error("Issuer not specified in claims")
     {}  
 };
 

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -434,11 +434,16 @@ public:
         m_validate_profile = profile;
     }
 
+    /**
+     * Store the contents of a public EC key for a given issuer.
+     */
+    static bool store_public_ec_key(const std::string &issuer, const std::string &kid, const std::string &key);
+
 private:
     void get_public_key_pem(const std::string &issuer, const std::string &kid, std::string &public_pem, std::string &algorithm);
     void get_public_keys_from_web(const std::string &issuer, picojson::value &keys, int64_t &next_update, int64_t &expires);
     bool get_public_keys_from_db(const std::string issuer, int64_t now, picojson::value &keys, int64_t &next_update);
-    bool store_public_keys(const std::string &issuer, const picojson::value &keys, int64_t next_update, int64_t expires);
+    static bool store_public_keys(const std::string &issuer, const picojson::value &keys, int64_t next_update, int64_t expires);
 
     bool m_validate_all_claims{true};
     SciToken::Profile m_profile{SciToken::Profile::COMPAT};

--- a/src/verify.cpp
+++ b/src/verify.cpp
@@ -1,13 +1,117 @@
-#include <iostream>
 
 #include "scitokens.h"
 
-int main(int argc, const char** argv) {
+#include <fstream>
+#include <iostream>
+#include <getopt.h>
+
+namespace {
+
+const char usage[] = \
+"\n"
+"Syntax: %s [--cred cred_file] TOKEN\n"
+"\n"
+" Options\n"
+"    -h | --help                  Display usage\n"
+"    -c | --cred     <cred_file>  File containing the signing credential.\n"
+"    -i | --issuer      <issuer>  Issuer of the token to verify.\n"
+"    -K | --keyid          <kid>  Name of the token key.\n"
+"    -p | --profile    <profile>  Profile to enforce (wlcg, scitokens1, scitokens2).\n"
+"\n";
+
+const struct option long_options[] =
+{
+    {"help",           no_argument, NULL, 'h'},
+    {"cred",     required_argument, NULL, 'c'},
+    {"issuer",   required_argument, NULL, 'i'},
+    {"keyid",    required_argument, NULL, 'K'},
+    {"profile",  required_argument, NULL, 'p'},
+    {0, 0, 0, 0}
+};
+
+const char short_options[] = "hc:i:K:p:";
+
+std::string g_cred, g_issuer, g_keyid, g_profile;
+
+int init_arguments(int argc, char * const argv[])
+{
+    int arg;
+    while((arg = getopt_long(argc, argv, short_options, long_options, nullptr)) != -1) {
+        switch (arg)
+        {
+        case 'h':
+            printf(usage, argv[0]);
+            exit(0);
+            break;
+        case 'c':
+            g_cred = optarg;
+            break;
+        case 'i':
+            g_issuer = optarg;
+            break;
+        case 'K':
+            g_keyid = optarg;
+            break;
+        case 'p':
+            g_profile = optarg;
+            break;
+        default:
+            fprintf(stderr, usage, argv[0]);
+            exit(1);
+            break;
+        }
+    }
+
+    if (optind < argc - 1) {
+        fprintf(stderr, "%s: invalid option -- %s\n", argv[0], argv[optind]);
+        fprintf(stderr, usage, argv[0]);
+        exit(1);
+    }
+
+    if (optind == argc) {
+        fprintf(stderr, "%s: Must provide a token as a requirement\n", argv[0]);
+        fprintf(stderr, usage, argv[0]);
+        exit(1);
+    }
+
+    if ((!g_cred.empty() || !g_issuer.empty() || !g_keyid.empty()) &&
+        (g_cred.empty() || g_issuer.empty() || g_keyid.empty()))
+    {
+        fprintf(stderr, "%s: If --cred, --keyid, or --issuer are set, then all must be set.\n", argv[0]);
+        fprintf(stderr, usage, argv[0]);
+        exit(1);
+    }
+
+    return 0;
+}
+
+}
+
+int main(int argc, char* const* argv) {
     if (argc < 2) {
-        std::cerr << "Usage: " << argv[0] << " (TOKEN)" << std::endl;
+        fprintf(stderr, "%s: Insufficient arguments; must at least provide a token.\n", argv[0]);
+        fprintf(stderr, usage, argv[0]);
         return 1;
     }
-    std::string token(argv[1]);
+    if (init_arguments(argc, argv)) {return 1;}
+
+    std::string token(argv[argc-1]);
+
+    if (!g_issuer.empty()) {
+        char *err_msg;
+
+        std::ifstream pub_ifs(g_cred);
+        std::string public_contents( (std::istreambuf_iterator<char>(pub_ifs)),
+                              (std::istreambuf_iterator<char>())
+                             );
+
+        auto rv = scitoken_store_public_ec_key(g_issuer.c_str(), g_keyid.c_str(), public_contents.c_str(), &err_msg);
+        if (rv) {
+            fprintf(stderr, "%s: %s\n", argv[0], err_msg);
+            free(err_msg);
+            return 1;
+        }
+    }
 
     SciToken scitoken;
     char *err_msg = nullptr;
@@ -16,6 +120,6 @@ int main(int argc, const char** argv) {
         return 1;
     }
     std::cout << "Token deserialization successful." << std::endl;
+
     return 0;
 }
-


### PR DESCRIPTION
This adds support for the WLCG profile, in addition to a number of tools to help in the testing of tokens.

One can now do the following:

```
export TOKEN=$(./scitokens-create --cred test.pem --key test.pem --keyid 1 --issuer https://demo.scitokens.org --claim 'scp=read:/' --claim foo=bar --profile scitokens2)

./scitokens-verify  --keyid 1 --issuer https://demo.scitokens.org --cred test.pem $TOKEN
```

(Even without WiFi!)