### PR TITLE
Fix gtest APIs and test cases

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -38,7 +38,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_UNITTESTS=yes
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -51,6 +51,6 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE
+      run: ctest -C $BUILD_TYPE --verbose
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,11 +79,9 @@ if( BUILD_UNITTESTS )
 include(ExternalProject)
 ExternalProject_Add(gtest
     PREFIX external/gtest
-    SOURCE_DIR ${PROJECT_SOURCE_DIR}/vendor/gtest
-    BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/external/gtest/src/gtest-build/lib/libgtest.a
+    URL file://${PROJECT_SOURCE_DIR}/vendor/gtest
     INSTALL_COMMAND :
 )
-
 enable_testing()
 add_subdirectory(test)
 endif()

--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -67,11 +67,24 @@ int scitoken_set_claim_string(SciToken token, const char *key, const char *value
 }
 
 
+void scitoken_set_serialize_profile(SciToken token, SciTokenProfile profile) {
+    scitoken_set_serialize_mode(token, profile);
+}
+
+
 void scitoken_set_serialize_mode(SciToken token, SciTokenProfile profile) {
     scitokens::SciToken *real_token = reinterpret_cast<scitokens::SciToken*>(token);
     if (real_token == nullptr) {return;}
 
     real_token->set_serialize_mode(static_cast<scitokens::SciToken::Profile>(profile));
+}
+
+
+void scitoken_set_deserialize_profile(SciToken token, SciTokenProfile profile) {
+    scitokens::SciToken *real_token = reinterpret_cast<scitokens::SciToken*>(token);
+    if (real_token == nullptr) {return;}
+
+    real_token->set_deserialize_mode(static_cast<scitokens::SciToken::Profile>(profile));
 }
 
 
@@ -150,6 +163,18 @@ int scitoken_deserialize(const char *value, SciToken *token, char const* const* 
     scitokens::SciTokenKey key;
     scitokens::SciToken *real_token = new scitokens::SciToken(key);
 
+    int retval = scitoken_deserialize_v2(value, reinterpret_cast<SciToken>(real_token), allowed_issuers, err_msg);
+    if (retval) {
+        delete real_token;
+    } else {
+        *token = real_token;
+    }
+    return retval;
+}
+
+int scitoken_deserialize_v2(const char *value, SciToken token, char const* const* allowed_issuers, char **err_msg) {
+    scitokens::SciToken *real_token = reinterpret_cast<scitokens::SciToken*>(token);
+
     std::vector<std::string> allowed_issuers_vec;
     if (allowed_issuers != nullptr) {
         for (int idx=0; allowed_issuers[idx]; idx++) {
@@ -165,7 +190,6 @@ int scitoken_deserialize(const char *value, SciToken *token, char const* const* 
         }
         return -1;
     }
-    *token = real_token;
     return 0;
 }
 

--- a/src/scitokens.h
+++ b/src/scitokens.h
@@ -57,9 +57,15 @@ int scitoken_serialize(const SciToken token, char **value, char **err_msg);
  * Set the profile used for serialization; if COMPAT mode is used, then
  * the library default is utilized (currently, scitokens 1.0).
  */
+void scitoken_set_serialize_profile(SciToken token, SciTokenProfile profile);
+
 void scitoken_set_serialize_mode(SciToken token, SciTokenProfile profile);
 
+void scitoken_set_deserialize_profile(SciToken token, SciTokenProfile profile);
+
 int scitoken_deserialize(const char *value, SciToken *token, char const* const* allowed_issuers, char **err_msg);
+
+int scitoken_deserialize_v2(const char *value, SciToken token, char const* const* allowed_issuers, char **err_msg);
 
 int scitoken_store_public_ec_key(const char *issuer, const char *keyid, const char *value, char **err_msg);
 

--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -341,6 +341,7 @@ SciToken::deserialize(const std::string &data, const std::vector<std::string> al
     scitokens::Validator val;
     val.add_allowed_issuers(allowed_issuers);
     val.set_validate_all_claims_scitokens_1(false);
+    val.set_validate_profile(m_deserialize_profile);
     val.verify(*m_decoded);
 
     // Set all the claims

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -187,7 +187,7 @@ public:
                 m_claims["aud"] = std::string("ANY");
             }
         } else if (m_serialize_profile == Profile::WLCG_1_0) {
-            m_claims["wlcg_ver"] = std::string("1.0");
+            m_claims["wlcg.ver"] = std::string("1.0");
             auto iter = m_claims.find("aud");
             if (iter == m_claims.end()) {
                 m_claims["aud"] = std::string("https://wlcg.cern.ch/jwt/v1/any");

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -134,6 +134,11 @@ public:
         m_serialize_profile = profile;
     }
 
+    void
+    set_deserialize_mode(Profile profile) {
+        m_deserialize_profile = profile;
+    }
+
     const jwt::claim
     get_claim(const std::string &key) {
         return m_claims[key];
@@ -205,6 +210,7 @@ private:
     int m_lifetime{600};
     Profile m_profile{Profile::SCITOKENS_1_0};
     Profile m_serialize_profile{Profile::COMPAT};
+    Profile m_deserialize_profile{Profile::COMPAT};
     std::unordered_map<std::string, jwt::claim> m_claims;
     std::unique_ptr<jwt::decoded_jwt> m_decoded;
     SciTokenKey &m_key;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,4 +3,11 @@ add_executable(scitokens-gtest main.cpp)
 add_dependencies(scitokens-gtest gtest)
 include_directories("${PROJECT_SOURCE_DIR}/vendor/gtest/googletest/include")
 
-target_link_libraries(scitokens-gtest SciTokens "${CMAKE_BINARY_DIR}/external/gtest/src/gtest-build/lib/libgtest.a")
+target_link_libraries(scitokens-gtest SciTokens "${CMAKE_BINARY_DIR}/external/gtest/src/gtest-build/lib/libgtest.a" -lpthread)
+
+add_test(
+  NAME
+    unit
+  COMMAND
+    ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/test/scitokens-gtest
+  )


### PR DESCRIPTION
Hm - it seems that gtest referred to some APIs that didn't exist and some test cases didn't pass.  Looks like the original gtest branch was missing a few commits (bad rebase perhaps)?

Regardless, with this, gtest now works again!

@djw8605 - can you ensure that gtest is being invoked by the GH actions workflows?