### PR TITLE
API for querying for string lists

### DIFF
--- a/src/scitokens.h
+++ b/src/scitokens.h
@@ -47,6 +47,27 @@ int scitoken_set_claim_string(SciToken token, const char *key, const char *value
 
 int scitoken_get_claim_string(const SciToken token, const char *key, char **value, char **err_msg);
 
+/**
+ * Given a SciToken object, parse a specific claim's value as a list of strings.  If the JSON value
+ * is not actually a list of strings - or the claim is not set - returns an error and sets the
+ * err_msg appropriately.
+ *
+ * The returned value is a list of strings that ends with a nullptr.
+ */
+int scitoken_get_claim_string_list(const SciToken token, const char *key, char ***value, char **err_msg);
+
+/**
+ * Given a list of strings that was returned by scitoken_get_claim_string_list, free all the associated
+ * memory.
+ */
+void scitoken_free_string_list(char **value);
+
+/**
+ * Set the value of a claim to a list of strings.
+ */
+int scitoken_set_claim_string_list(const SciToken token, const char *key,
+    const char **values, char **err_msg);
+
 int scitoken_get_expiration(const SciToken token, long long *value, char **err_msg);
 
 void scitoken_set_lifetime(SciToken token, int lifetime);

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -149,12 +149,37 @@ public:
         return m_claims.find(key) != m_claims.end();
     }
 
+    void
+    set_claim_list(const std::string &claim, std::vector<std::string> &claim_list) {
+        picojson::array array;
+        array.reserve(claim_list.size());
+        for (const auto &entry : claim_list) {
+            array.emplace_back(entry);
+        }
+        m_claims[claim] = jwt::claim(picojson::value(array));
+    }
+
     // Return a claim as a string
     // If the claim is not a string, it can throw
     // a std::bad_cast() exception.
     const std::string
     get_claim_string(const std::string &key) {
         return m_claims[key].as_string();
+    }
+
+    const std::vector<std::string>
+    get_claim_list(const std::string &key) {
+        picojson::array array;
+        try {
+            array = m_claims[key].as_array();
+        } catch (std::bad_cast &) {
+            throw JsonException("Claim's value is not a JSON list");
+        }
+       std::vector<std::string> result;
+       for (const auto &value : array) {
+           result.emplace_back(value.get<std::string>());
+       }
+       return result;
     }
 
     void

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -77,6 +77,15 @@ class SerializeTest : public ::testing::Test {
                 "1", ec_public, &err_msg);
             ASSERT_TRUE(rv == 0);
 
+            const char *groups[3] = {nullptr, nullptr, nullptr};
+            const char group0[] = "group0";
+            const char group1[] = "group1";
+            groups[0] = group0;
+            groups[1] = group1;
+            rv = scitoken_set_claim_string_list(m_token.get(), "groups", groups,
+                &err_msg);
+            ASSERT_TRUE(rv == 0);
+
             m_read_token.reset(scitoken_create(nullptr));
             ASSERT_TRUE(m_read_token.get() != nullptr);
         }
@@ -113,6 +122,23 @@ TEST_F(SerializeTest, VerifyTest) {
     value_ptr.reset();
     rv = scitoken_get_claim_string(m_read_token.get(), "doesnotexist", &value, &err_msg);
     EXPECT_FALSE(rv == 0);
+}
+
+TEST_F(SerializeTest, TestStringList) {
+    char *err_msg = nullptr;
+
+    char **value;
+    auto rv = scitoken_get_claim_string_list(m_token.get(), "groups", &value, &err_msg);
+    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(value != nullptr);
+
+    ASSERT_TRUE(value[0] != nullptr);
+    EXPECT_STREQ(value[0], "group0");
+
+    ASSERT_TRUE(value[1] != nullptr);
+    EXPECT_STREQ(value[1], "group1");
+
+    EXPECT_TRUE(value[2] == nullptr);
 }
 
 


### PR DESCRIPTION
This adds a simple API for querying for a list of strings set as values in a claim.

This should be useful for things in the future such as getting a list of groups from the token's claims.

(NOTE: This is built on the `fix_gtest` branch in #23 -- merge that first)