### PR TITLE
Update to jwt-cpp-0.4.0

### DIFF
--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -56,7 +56,7 @@ int scitoken_set_claim_string(SciToken token, const char *key, const char *value
         return -1;
     }
     try {
-        real_token->set_claim(key, std::string(value));
+        real_token->set_claim(key, jwt::claim(std::string(value)));
     } catch (std::exception &exc) {
         if (err_msg) {
             *err_msg = strdup(exc.what());

--- a/src/scitokens_cache.cpp
+++ b/src/scitokens_cache.cpp
@@ -11,7 +11,7 @@
 #ifndef PICOJSON_USE_INT64
 #define PICOJSON_USE_INT64
 #endif
-#include <jwt-cpp/picojson.h>
+#include <picojson/picojson.h>
 #include <sqlite3.h>
 
 #include "scitokens_internal.h"

--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -5,7 +5,7 @@
 #include <curl/curl.h>
 #include <jwt-cpp/base.h>
 #include <jwt-cpp/jwt.h>
-#include <jwt-cpp/picojson.h>
+#include <picojson/picojson.h>
 #include <openssl/bn.h>
 #include <openssl/ec.h>
 

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -203,19 +203,19 @@ public:
         uuid_generate(uuid);
         char uuid_str[37];
         uuid_unparse_lower(uuid, uuid_str);
-        m_claims["jti"] = std::string(uuid_str);
+        m_claims["jti"] = jwt::claim(std::string(uuid_str));
 
         if (m_serialize_profile == Profile::SCITOKENS_2_0) {
-            m_claims["ver"] = std::string("scitokens:2.0");
+            m_claims["ver"] = jwt::claim(std::string("scitokens:2.0"));
             auto iter = m_claims.find("aud");
             if (iter == m_claims.end()) {
-                m_claims["aud"] = std::string("ANY");
+                m_claims["aud"] = jwt::claim(std::string("ANY"));
             }
         } else if (m_serialize_profile == Profile::WLCG_1_0) {
-            m_claims["wlcg.ver"] = std::string("1.0");
+            m_claims["wlcg.ver"] = jwt::claim(std::string("1.0"));
             auto iter = m_claims.find("aud");
             if (iter == m_claims.end()) {
-                m_claims["aud"] = std::string("https://wlcg.cern.ch/jwt/v1/any");
+                m_claims["aud"] = jwt::claim(std::string("https://wlcg.cern.ch/jwt/v1/any"));
             }
         }
 


### PR DESCRIPTION
This PR fixes #33 and replaces #16 by fixing some compiler errors and updating to use jwt-cpp 0.4.0 (the latest stable release).