### PR TITLE
Use GNUInstallDirs to define default cmake install destinations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ option( BUILD_UNITTESTS "Build the scitokens-cpp unit tests" OFF )
 
 set( CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 
+include(GNUInstallDirs)
+
 find_package( jwt-cpp REQUIRED )
 find_package( CURL REQUIRED )
 find_package( UUID REQUIRED )
@@ -66,14 +68,6 @@ target_link_libraries(scitokens-list-access SciTokens)
 add_executable(scitokens-create src/create.cpp)
 target_link_libraries(scitokens-create SciTokens)
 
-if (NOT DEFINED LIB_INSTALL_DIR)
-  SET(LIB_INSTALL_DIR "lib")
-endif()
-
-if (NOT DEFINED INCLUDE_INSTALL_DIR)
-  SET(INCLUDE_INSTALL_DIR "include")
-endif()
-
 if( BUILD_UNITTESTS )
 
 include(ExternalProject)
@@ -88,11 +82,11 @@ endif()
 
 install(
   TARGETS SciTokens
-  LIBRARY DESTINATION ${LIB_INSTALL_DIR} )
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 
 install(
   FILES src/scitokens.h
-  DESTINATION ${INCLUDE_INSTALL_DIR}/scitokens )
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/scitokens )
 
 set_target_properties(
   SciTokens

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,5 +9,5 @@ add_test(
   NAME
     unit
   COMMAND
-    ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/test/scitokens-gtest
+    ${CMAKE_CURRENT_BINARY_DIR}/scitokens-gtest
   )


### PR DESCRIPTION
This PR modifies the `CMakeLists.txt` to use [`GNUInstallDirs`](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html) to define the default install destinations. This is pretty standard and is expected to be used by [conda build](https://github.com/conda-forge/ctng-compiler-activation-feedstock/blob/6290f55b73a887086b0efe0cdb32553646696a8a/recipe/activate-gcc.sh#L144), [`debhelper`](https://github.com/Debian/debhelper/blob/5d1bb29841043d8e47ebbdd043e6cd086cad508e/lib/Debian/Debhelper/Buildsystem/cmake.pm#L14-L21), and [`rpmbuild`](https://src.fedoraproject.org/rpms/cmake/blob/f34/f/macros.cmake#_29).