### PR TITLE
Allow disabling build of vendored gtest with new cmake option EXTERNAL_GTEST

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required( VERSION 2.6 )
 project( scitokens-cpp )
 
 option( BUILD_UNITTESTS "Build the scitokens-cpp unit tests" OFF )
+option( EXTERNAL_GTEST "Use an external/pre-installed copy of GTest" OFF )
 
 set( CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 
@@ -75,13 +76,14 @@ if (NOT DEFINED INCLUDE_INSTALL_DIR)
 endif()
 
 if( BUILD_UNITTESTS )
-
+if( NOT EXTERNAL_GTEST )
 include(ExternalProject)
 ExternalProject_Add(gtest
     PREFIX external/gtest
-    URL file://${PROJECT_SOURCE_DIR}/vendor/gtest
+    URL ${CMAKE_CURRENT_SOURCE_DIR}/vendor/gtest
     INSTALL_COMMAND :
 )
+endif()
 enable_testing()
 add_subdirectory(test)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,13 @@ add_executable(scitokens-gtest main.cpp)
 add_dependencies(scitokens-gtest gtest)
 include_directories("${PROJECT_SOURCE_DIR}/vendor/gtest/googletest/include")
 
-target_link_libraries(scitokens-gtest SciTokens "${CMAKE_BINARY_DIR}/external/gtest/src/gtest-build/lib/libgtest.a" -lpthread)
+if(EXTERNAL_GTEST)
+    set(LIBGTEST "gtest")
+else()
+    set(LIBGTEST "${CMAKE_BINARY_DIR}/external/gtest/src/gtest-build/lib/libgtest.a")
+endif()
+
+target_link_libraries(scitokens-gtest SciTokens "${LIBGTEST}" pthread)
 
 add_test(
   NAME


### PR DESCRIPTION
This PR adds a new CMake option `EXTERNAL_GTEST` (default `OFF`) which allows disabling the build of the vendored `gtest` for the test suite.

~~I also added `-DBUILD_UNITTESTS:BOOL=TRUE -DEXTERNAL_GTEST:BOOL=TRUE` and a `%check` section to the rpm build to run the tests there.~~ EDIT: this was dropped because EPEL7's `gtest` is too old, and adding a bunch of `%if` macros in the spec file seemed like a lot of work...

Fixed #46.