### PR TITLE
scitokens_internal: Fix undefined behaviour in CURL write functions.

### DIFF
--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -46,7 +46,10 @@ public:
         }
 
         if (m_maxbytes > 0) {
-            m_data.reserve(std::min(m_maxbytes, 8*1024));
+            size_t new_size = std::min(m_maxbytes, 8*1024);
+            if (m_data.size() < new_size) {
+                m_data.resize(new_size);
+            }
         }
 
         curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
@@ -82,7 +85,9 @@ private:
         if (myself->m_maxbytes > 0 && (new_length > static_cast<size_t>(myself->m_maxbytes))) {
             return 0;
         }
-        myself->m_data.reserve(new_length);
+        if (myself->m_data.size() < new_length) {
+            myself->m_data.resize(new_length);
+        }
         memcpy(&(myself->m_data[myself->m_len]), buffer, new_data);
         myself->m_len = new_length;
         return new_data;


### PR DESCRIPTION
Since std::vector<>.reserve() does not allocate,
accessing elements may lead to undefined behaviour
(and triggers asserts with build fortification on CentOS 8).
Use resize() as-needed instead to allocate the necessary space.

This is basically a variant of #39. The associated trace was:
```
#0  0x00007f3ff757f7ff in raise () from /lib64/libc.so.6
#1  0x00007f3ff7569c35 in abort () from /lib64/libc.so.6
#2  0x00007f3ff048b2d8 in std::__replacement_assert (__file=__file@entry=0x7f3ff04a8bc8 "/usr/include/c++/8/bits/stl_vector.h", __line=__line@entry=932, 
    __function=__function@entry=0x7f3ff04a9440 <std::vector<char, std::allocator<char> >::operator[](unsigned long)::__PRETTY_FUNCTION__> "std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = char; _Alloc = std::allocator<char>; std::vector<_Tp, _Alloc>::reference = cha"..., __condition=__condition@entry=0x7f3ff04a8b98 "__builtin_expect(__n < this->size(), true)")
    at /usr/include/c++/8/x86_64-redhat-linux/bits/c++config.h:2391
#3  0x00007f3ff049abbf in std::vector<char, std::allocator<char> >::operator[] (__n=<optimized out>, this=<optimized out>) at /usr/src/debug/scitokens-cpp-0.6.0-1.el8.x86_64/src/scitokens_internal.cpp:77
#4  (anonymous namespace)::SimpleCurlGet::write_data (buffer=0x7f3fdc0499d5, size=<optimized out>, nmemb=<optimized out>, userp=0x7f3ff4271c30) at /usr/src/debug/scitokens-cpp-0.6.0-1.el8.x86_64/src/scitokens_internal.cpp:86
#5  (anonymous namespace)::SimpleCurlGet::write_data (buffer=0x7f3fdc0499d5, size=<optimized out>, nmemb=<optimized out>, userp=0x7f3ff4271c30) at /usr/src/debug/scitokens-cpp-0.6.0-1.el8.x86_64/src/scitokens_internal.cpp:77
#6  0x00007f3ff020c594 in Curl_client_write () from /lib64/libcurl.so.4
#7  0x00007f3ff021f9c3 in Curl_readwrite () from /lib64/libcurl.so.4
#8  0x00007f3ff0229194 in multi_runsingle () from /lib64/libcurl.so.4
#9  0x00007f3ff022a341 in curl_multi_perform () from /lib64/libcurl.so.4
#10 0x00007f3ff0220d0b in curl_easy_perform () from /lib64/libcurl.so.4
#11 0x00007f3ff049ac9e in (anonymous namespace)::SimpleCurlGet::perform (this=0x7f3ff4271c30, url="https://wlcg.cloud.cnaf.infn.it//.well-known/openid-configuration") at /usr/src/debug/scitokens-cpp-0.6.0-1.el8.x86_64/src/scitokens_internal.cpp:56
#12 0x00007f3ff049db53 in scitokens::Validator::get_public_keys_from_web (this=<optimized out>, issuer=..., keys=..., next_update=@0x7f3ff4271f80: 0, expires=@0x7f3ff4271f88: 0)
    at /usr/src/debug/scitokens-cpp-0.6.0-1.el8.x86_64/src/scitokens_internal.cpp:363
#13 0x00007f3ff049f473 in scitokens::Validator::get_public_key_pem (this=this@entry=0x7f3ff4272850, issuer="https://wlcg.cloud.cnaf.infn.it/", kid="rsa1", public_pem="", algorithm="")
    at /usr/src/debug/scitokens-cpp-0.6.0-1.el8.x86_64/src/scitokens_internal.cpp:427
...
```

@djw8605 This patch fixes the observed issue, I tested by rebuilding the RPM afterwards. I have not given it extensive testing, though. 