### PR TITLE
RPM: Depend on cmake3 instead of cmake on EL7.

### DIFF
--- a/rpm/scitokens-cpp.spec
+++ b/rpm/scitokens-cpp.spec
@@ -19,7 +19,11 @@ Source0: https://github.com/scitokens/scitokens-cpp/releases/download/v%{version
 
 BuildRequires: gcc-c++
 BuildRequires: make
+%if 0%{?el7}
+BuildRequires: cmake3
+%else
 BuildRequires: cmake
+%endif
 BuildRequires: sqlite-devel
 BuildRequires: openssl-devel
 BuildRequires: libcurl-devel


### PR DESCRIPTION
Otherwise, the `%cmake3` macro is not present and RPM building fails.
Fixes CI check.