### PR TITLE
Add support for building debian in cvmfs-contrib OBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,10 @@ SciTokens-cpp includes a submodule, jwt-cpp.  Therefore, to create a release, yo
     git submodule update --init
     git submodule foreach --recursive "git archive --prefix=scitokens-cpp-0.3.3/\$path/ --output=\$sha1.tar HEAD && tar --concatenate --file=$(pwd)/scitokens-cpp-0.3.3.tar \$sha1.tar && rm \$sha1.tar"
     gzip "scitokens-cpp-0.3.3.tar"
+
+This package is built on the
+[cvmfs-config OpenSUSE Build Service](https://build.opensuse.org/project/show/home:cvmfs:contrib).
+In order to support that run `debian/obsupdate.sh` whenever the version
+or release number is changed in `rpm/scitokens-cpp.spec`, and commit the
+generated `debian/scitokens-cpp.dsc` before tagging the release.
+

--- a/cmake/FindUUID.cmake
+++ b/cmake/FindUUID.cmake
@@ -13,12 +13,6 @@
 #  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 #
 
-include(CheckSymbolExists)
-
-# On mac, it can't find uuid library
-# So, just check for the functions with the default include
-CHECK_SYMBOL_EXISTS("uuid_generate" "uuid/uuid.h" UUID_SYMBOL)
-
 if (UUID_SYMBOL)
   set(UUID_FOUND TRUE)
 elseif (UUID_LIBRARIES AND UUID_INCLUDE_DIRS)

--- a/debian/README.obs
+++ b/debian/README.obs
@@ -1,0 +1,5 @@
+This package is built by cvmfs-contrib on the OpenSUSE Build System
+  https://build.opensuse.org/project/show/home:cvmfs:contrib
+OBS requires a little help from the package in order to build on 
+Debian.  Each time there's a new release, run obsupdate.sh in this
+directory and commit the newly updated scitokens-cpp.dsc.

--- a/debian/obsupdate.sh
+++ b/debian/obsupdate.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# update ../packaging/debian/packageName.dsc
+# That file is used by build.opensuse.org's Open Build Service
+# After the file is updated, it needs to be separately committed to git.
+
+HERE="`dirname $0`"
+ME="`basename $0`"
+cd $HERE
+PKG="`sed -n 's/^Source: //p' control`"
+SPECFILE="../rpm/$PKG.spec"
+VERSION="$(grep ^Version: $SPECFILE | awk '{print $2}')"
+RPMREL="$(grep '^%define release_prefix' $SPECFILE | awk '{print $3}')"
+if [ -z "$RPMREL" ]; then
+    RPMREL="$(grep '^Release:' $SPECFILE | awk '{print $2}' | cut -d% -f1)"
+fi
+# if the version is current, increment the release number, else choose 1
+DEBREL="`sed -n "s/^Version: ${VERSION}\.${RPMREL}-//p" $PKG.dsc 2>/dev/null`"
+if [ -z "$DEBREL" ]; then
+    DEBREL=1
+else
+    let DEBREL+=1
+fi
+(
+echo "# created by $ME, do not edit by hand"
+# The following two lines are OBS "magic" to use the tarball from the rpm
+echo "Debtransform-Tar: ${PKG}-${VERSION}.tar.gz"
+#echo "Debtransform-Files-Tar: "
+echo "Format: 3.0"
+echo "Version: ${VERSION}.${RPMREL}-${DEBREL}"
+echo "Binary: $PKG"
+cat control
+echo "Files:"
+echo "  ffffffffffffffffffffffffffffffff 99999 file1"
+echo "  ffffffffffffffffffffffffffffffff 99999 file2"
+) > $PKG.dsc
+#
+echo "Updated $PWD/$PKG.dsc"

--- a/debian/scitokens-cpp.dsc
+++ b/debian/scitokens-cpp.dsc
@@ -1,0 +1,49 @@
+# created by obsupdate.sh, do not edit by hand
+Debtransform-Tar: scitokens-cpp-0.6.3.tar.gz
+Format: 3.0
+Version: 0.6.3.1-2
+Binary: scitokens-cpp
+Source: scitokens-cpp
+Section: science
+Priority: optional
+Maintainer: Tim Theisen <tim@cs.wisc.edu>
+Build-Depends:
+    cmake (>=2.6),
+    debhelper (>=9),
+    libcurl4-openssl-dev | libcurl4-gnutls-dev,
+    libsqlite3-dev,
+    libssl-dev,
+    pkg-config,
+    uuid-dev
+Standards-Version: 3.9.8
+Homepage: https://github.com/scitokens/scitokens-cpp
+
+Package: libscitokens0
+Section: libs
+Architecture: any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: C++ Implementation of the SciTokens Library
+ SciTokens provide a token format for distributed authorization
+ The tokens are self-describing, can be verified in a distributed fashion
+ (no need to contact the issuer to determine if the token is valid).
+ This is convenient for a federated environment where several
+ otherwise-independent storage endpoints want to delegate trust for
+ an issuer for managing a storage allocation.
+
+Package: libscitokens-dev
+Section: libdevel
+Architecture: any
+Multi-Arch: same
+Depends: libscitokens0 (= ${binary:Version}), ${misc:Depends}
+Description: Header files for the libscitokens public interfaces
+ SciTokens provide a token format for distributed authorization.
+ The tokens are self-describing, can be verified in a distributed fashion
+ (no need to contact the issuer to determine if the token is valid).
+ This is convenient for a federated environment where several
+ otherwise-independent storage endpoints want to delegate trust for
+ an issuer for managing a storage allocation.
+Files:
+  ffffffffffffffffffffffffffffffff 99999 file1
+  ffffffffffffffffffffffffffffffff 99999 file2

--- a/rpm/scitokens-cpp.spec
+++ b/rpm/scitokens-cpp.spec
@@ -1,6 +1,6 @@
 Name: scitokens-cpp
-Version: 0.6.2
-Release: 2%{?dist}
+Version: 0.6.3
+Release: 1%{?dist}
 Summary: C++ Implementation of the SciTokens Library
 License: ASL 2.0
 URL: https://github.com/scitokens/scitokens-cpp
@@ -60,6 +60,9 @@ Requires: %{name}%{?_isa} = %{version}
 %dir %{_includedir}/scitokens
 
 %changelog
+* Fri Aug 27 2021 Dave Dykstra <dwd@fnal.gov> - 0.6.3-1
+- Add support for building Debian packages on the OpenSUSE Build System
+
 * Thu Aug 26 2021 Dave Dykstra <dwd@fnal.gov> - 0.6.2-2
 - Make the build require cmake3 instead of cmake
 


### PR DESCRIPTION
This adds support for building for Debian in cvmfs-contrib's Opensuse Build System.  It updates to version 0.6.3 at the same time because that affects the Debian package.

This doesn't build on Debian 11, Ubuntu 20.10, or Ubuntu 21.04 because of a compilation problem in jwt-cpp.  I think that might be fixed by updating that submodule to the latest version, but as it turns out it's not so important because OBS doesn't need to build scitokens-cpp in Debian 11 or Ubuntu 21.04 because it's already natively available there.  It still might be wanted for Ubuntu 20.10.

So really, this is only for support on Debian versions older than 11 and Ubuntu versions older than 21.04.