### PR TITLE
Add requiring epel-rpm-macros on el7

### DIFF
--- a/rpm/scitokens-cpp.spec
+++ b/rpm/scitokens-cpp.spec
@@ -24,6 +24,10 @@ BuildRequires: sqlite-devel
 BuildRequires: openssl-devel
 BuildRequires: libcurl-devel
 BuildRequires: libuuid-devel
+%if 0%{?el7}
+# needed for ldconfig_scriptlets
+BuildRequires: epel-rpm-macros
+%endif
 
 %description
 %{summary}


### PR DESCRIPTION
This makes the %ldconfig_scriptlets macro work on el7.  Discussed in #62.