### PR TITLE
Add scitokens-* binaries to the packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,9 +82,9 @@ enable_testing()
 add_subdirectory(test)
 endif()
 
+get_directory_property(TARGETS BUILDSYSTEM_TARGETS)
 install(
-  TARGETS SciTokens
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )
+  TARGETS ${TARGETS} )
 
 install(
   FILES src/scitokens.h

--- a/debian/libscitokens0.install
+++ b/debian/libscitokens0.install
@@ -1,1 +1,2 @@
 debian/tmp/usr/lib/*/libSciTokens.so.*
+debian/tmp/usr/bin/scitokens-*

--- a/rpm/scitokens-cpp.spec
+++ b/rpm/scitokens-cpp.spec
@@ -56,6 +56,7 @@ Requires: %{name}%{?_isa} = %{version}
 
 %files
 %{_libdir}/libSciTokens.so.0*
+%{_bindir}/scitokens-*
 %license LICENSE
 %doc README.md
 
@@ -65,6 +66,8 @@ Requires: %{name}%{?_isa} = %{version}
 %dir %{_includedir}/scitokens
 
 %changelog
+#- Add scitokens-* binaries to the package
+
 * Fri Sep 03 2021 Dave Dykstra <dwd@fnal.gov> - 0.6.3-1
 - Add support for building Debian packages on the OpenSUSE Build System
 - Add patch to jwt-cpp to update its picojson dependency in order to


### PR DESCRIPTION
I found the scitoken-* binaries to be quite useful, especially scitokens-verify.  This PR adds them to the rpm and debian packages in /usr/bin.