### PR TITLE
Add support for at+jwt profile.

### DIFF
--- a/src/create.cpp
+++ b/src/create.cpp
@@ -23,7 +23,7 @@ const char usage[] = \
 "    -k | --key             <key_file>  File containing the signing private key.\n"
 "    -K | --keyid                <kid>  Name of the token key.\n"
 "    -i | --issuer            <issuer>  Issuer for the token.\n"
-"    -p | --profile          <profile>  Token profile (wlcg, scitokens1, scitokens2).\n"
+"    -p | --profile          <profile>  Token profile (wlcg, scitokens1, scitokens2, atjwt).\n"
 "\n";
 
 const struct option long_options[] =
@@ -180,6 +180,8 @@ int main(int argc, char *argv[]) {
             profile = SciTokenProfile::SCITOKENS_1_0;
         } else if (g_profile == "scitokens2") {
             profile = SciTokenProfile::SCITOKENS_2_0;
+        } else if (g_profile == "atjwt") {
+            profile = SciTokenProfile::AT_JWT;
         } else {
             fprintf(stderr, "Unknown token profile: %s\n", g_profile.c_str());
             return 1;

--- a/src/scitokens.h
+++ b/src/scitokens.h
@@ -25,14 +25,16 @@ Acl;
  * - COMPAT mode (default) indicates any supported token format
  *   is acceptable.  Where possible, the scope names are translated into
  *   equivalent SciTokens 1.0 claim names (i.e., storage.read -> read; storage.write -> write).
- * - SCITOKENS_1_0, SCITOKENS_2_0, WLCG_1_0: only accept these specific profiles.
+ *   If a typ header claim is present, use that to deduce type (RFC8725 Section 3.11).
+ * - SCITOKENS_1_0, SCITOKENS_2_0, WLCG_1_0, AT_JWT: only accept these specific profiles.
  *   No automatic translation is performed.
  */
 typedef enum _profile {
     COMPAT = 0,
     SCITOKENS_1_0,
     SCITOKENS_2_0,
-    WLCG_1_0
+    WLCG_1_0,
+    AT_JWT
 } SciTokenProfile;
 
 SciTokenKey scitoken_key_create(const char *key_id, const char *algorithm, const char *public_contents, const char *private_contents, char **err_msg);

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -116,7 +116,8 @@ public:
         COMPAT = 0,
         SCITOKENS_1_0,
         SCITOKENS_2_0,
-        WLCG_1_0
+        WLCG_1_0,
+        AT_JWT
     };
 
     SciToken(SciTokenKey &signing_algorithm)
@@ -198,6 +199,9 @@ public:
         builder.set_issued_at(time);
         builder.set_not_before(time);
         builder.set_expires_at(time + std::chrono::seconds(m_lifetime));
+        if (m_serialize_profile == Profile::AT_JWT) {
+            builder.set_type("at+jwt");
+        }
 
         uuid_t uuid;
         uuid_generate(uuid);
@@ -258,11 +262,31 @@ public:
     }
 
     void verify(const jwt::decoded_jwt &jwt) {
+        // If token has a typ header claim (RFC8725 Section 3.11), trust that in COMPAT mode.
+        if (jwt.has_type()) {
+            std::string t_type = jwt.get_type();
+            if (m_validate_profile == SciToken::Profile::COMPAT) {
+                if (t_type == "at+jwt" || t_type == "application/at+jwt") {
+                    m_profile = SciToken::Profile::AT_JWT;
+                }
+            } else if (m_validate_profile == SciToken::Profile::AT_JWT) {
+                if (t_type != "at+jwt" && t_type != "application/at+jwt") {
+                    throw jwt::token_verification_exception("'typ' header claim must be at+jwt");
+                }
+                m_profile = SciToken::Profile::AT_JWT;
+            }
+        } else {
+            if (m_validate_profile == SciToken::Profile::AT_JWT) {
+                throw jwt::token_verification_exception("'typ' header claim must be set for at+jwt tokens");
+            }
+        }
         if (!jwt.has_payload_claim("iat")) {
             throw jwt::token_verification_exception("'iat' claim is mandatory");
         }
-        if (!jwt.has_payload_claim("nbf")) {
-            throw jwt::token_verification_exception("'nbf' claim is mandatory");
+        if (m_profile != SciToken::Profile::AT_JWT) {
+            if (!jwt.has_payload_claim("nbf")) {
+                throw jwt::token_verification_exception("'nbf' claim is mandatory");
+            }
         }
         if (!jwt.has_payload_claim("exp")) {
             throw jwt::token_verification_exception("'exp' claim is mandatory");
@@ -360,6 +384,9 @@ public:
             if (!jwt.has_payload_claim("aud")) {
                 throw jwt::token_verification_exception("Malformed token: 'aud' claim required for WLCG profile");
             }
+        } else if (m_profile == SciToken::Profile::AT_JWT) {
+            // detected early above from typ header claim.
+            must_verify_everything = false;
         } else {
             if ((m_validate_profile != SciToken::Profile::COMPAT) &&
                 (m_validate_profile != SciToken::Profile::SCITOKENS_1_0))

--- a/src/verify.cpp
+++ b/src/verify.cpp
@@ -16,7 +16,7 @@ const char usage[] = \
 "    -c | --cred     <cred_file>  File containing the signing credential.\n"
 "    -i | --issuer      <issuer>  Issuer of the token to verify.\n"
 "    -K | --keyid          <kid>  Name of the token key.\n"
-"    -p | --profile    <profile>  Profile to enforce (wlcg, scitokens1, scitokens2).\n"
+"    -p | --profile    <profile>  Profile to enforce (wlcg, scitokens1, scitokens2, atjwt).\n"
 "\n";
 
 const struct option long_options[] =

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -207,6 +207,53 @@ TEST_F(SerializeTest, FailVerifyToken) {
     EXPECT_FALSE(rv == 0);
 }
 
+TEST_F(SerializeTest, VerifyATJWTTest) {
+
+    char *err_msg = nullptr;
+
+    // Serialize as at+jwt token.
+    char *token_value = nullptr;
+    scitoken_set_serialize_profile(m_token.get(), SciTokenProfile::AT_JWT);
+    auto rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
+    ASSERT_TRUE(rv == 0);
+    std::unique_ptr<char, decltype(&free)> token_value_ptr(token_value, free);
+
+    // Accepts any profile.
+    rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr, &err_msg);
+    ASSERT_TRUE(rv == 0);
+
+    // Accepts only an at+jwt token, should work with at+jwt token
+    scitoken_set_deserialize_profile(m_read_token.get(), SciTokenProfile::AT_JWT);
+    rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr, &err_msg);
+    ASSERT_TRUE(rv == 0);
+
+    // Accepts only SciToken 2.0; should fail
+    scitoken_set_deserialize_profile(m_read_token.get(), SciTokenProfile::SCITOKENS_2_0);
+    rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr, &err_msg);
+    ASSERT_FALSE(rv == 0);
+}
+
+TEST_F(SerializeTest, FailVerifyATJWTTest) {
+
+    char *err_msg = nullptr;
+
+    // Serialize as "compat" token.
+    char *token_value = nullptr;
+    scitoken_set_serialize_profile(m_token.get(), SciTokenProfile::COMPAT);
+    auto rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
+    ASSERT_TRUE(rv == 0);
+    std::unique_ptr<char, decltype(&free)> token_value_ptr(token_value, free);
+
+    // Accepts any profile.
+    rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr, &err_msg);
+    ASSERT_TRUE(rv == 0);
+
+    // Accepts only an at+jwt token, should fail with COMPAT token
+    scitoken_set_deserialize_profile(m_read_token.get(), SciTokenProfile::AT_JWT);
+    rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr, &err_msg);
+    ASSERT_FALSE(rv == 0);
+}
+
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This adds support for the at-jwt type (RFC9068),
indicated and detectable from the `typ` header claim
as outlined in RFC8725 Section 3.11.

Used by Unity IAM which is used e.g. by the Helmholtz AAI.

This addresses #53. After applying this PR and #55, Unity IAM tokens are accepted in the `COMPAT` profile and the new `AT_JWT` profile. The `COMPAT` profile detects the `typ` header claim and switches to that accordingly. 