### PR TITLE
Enabling unit tests should not disable install of libraries and binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,14 +80,13 @@ ExternalProject_Add(gtest
 endif()
 enable_testing()
 add_subdirectory(test)
+endif()
 
-else()
 get_directory_property(TARGETS BUILDSYSTEM_TARGETS)
 install(
   TARGETS ${TARGETS} 
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
-endif()
 
 install(
   FILES src/scitokens.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,19 +69,6 @@ target_link_libraries(scitokens-list-access SciTokens)
 add_executable(scitokens-create src/create.cpp)
 target_link_libraries(scitokens-create SciTokens)
 
-if( BUILD_UNITTESTS )
-if( NOT EXTERNAL_GTEST )
-include(ExternalProject)
-ExternalProject_Add(gtest
-    PREFIX external/gtest
-    URL ${CMAKE_CURRENT_SOURCE_DIR}/vendor/gtest
-    INSTALL_COMMAND :
-)
-endif()
-enable_testing()
-add_subdirectory(test)
-endif()
-
 get_directory_property(TARGETS BUILDSYSTEM_TARGETS)
 install(
   TARGETS ${TARGETS} 
@@ -99,3 +86,15 @@ set_target_properties(
   SOVERSION "0"
   )
 
+if( BUILD_UNITTESTS )
+if( NOT EXTERNAL_GTEST )
+include(ExternalProject)
+ExternalProject_Add(gtest
+    PREFIX external/gtest
+    URL ${CMAKE_CURRENT_SOURCE_DIR}/vendor/gtest
+    INSTALL_COMMAND :
+)
+endif()
+enable_testing()
+add_subdirectory(test)
+endif()


### PR DESCRIPTION
If unit tests are enabled only the header file is installed.