### PR TITLE
fix apparent fd-leak of sqlite handle

### DIFF
--- a/src/scitokens_cache.cpp
+++ b/src/scitokens_cache.cpp
@@ -250,5 +250,6 @@ scitokens::Validator::store_public_keys(const std::string &issuer, const picojso
 
     sqlite3_exec(db, "COMMIT", 0, 0 , 0);
 
+    sqlite3_close(db);
     return true;
 }

--- a/src/scitokens_cache.cpp
+++ b/src/scitokens_cache.cpp
@@ -250,6 +250,7 @@ scitokens::Validator::store_public_keys(const std::string &issuer, const picojso
 
     sqlite3_exec(db, "COMMIT", 0, 0 , 0);
 
+    sqlite3_finalize(stmt);
     sqlite3_close(db);
     return true;
 }


### PR DESCRIPTION
(attn: @brianhlin @djw8605, i don't have permissions to assign a reviewer for this)

I'm seeing condor_schedd accumulating open fds pointing to `/var/lib/condor/.cache/scitokens/scitokens_cpp.sqllite` (thousands), without ever getting closed.

I looked around the sources here and _every_ other `return` in a function that opens this db is preceeded by a `sqlite3_close(db);` .  Presumably this one here is the source of the leak and just got missed.