### PR TITLE
gh-action: Adapt unittests to renamed CMake flags, fix using external gtest.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -44,7 +44,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_UNITTESTS=yes -DEXTERNAL_GTEST=${{ matrix.external-gtest }}
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSCITOKENS_BUILD_UNITTESTS=yes -DSCITOKENS_EXTERNAL_GTEST=${{ matrix.external-gtest }}
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 add_executable(scitokens-gtest main.cpp)
-add_dependencies(scitokens-gtest gtest)
+if( NOT SCITOKENS_EXTERNAL_GTEST )
+    add_dependencies(scitokens-gtest gtest)
+endif()
 include_directories("${PROJECT_SOURCE_DIR}/vendor/gtest/googletest/include")
 
 if(SCITOKENS_EXTERNAL_GTEST)


### PR DESCRIPTION
This adapts the unit tests (in GitHub actions) to use the now prefixed CMake flags, changed as part of #84 .
Thanks for the very welcome change :+1: . 