### PR TITLE
CMake: don't add bundled gtest include dir when using external gtest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,8 +2,8 @@
 add_executable(scitokens-gtest main.cpp)
 if( NOT SCITOKENS_EXTERNAL_GTEST )
     add_dependencies(scitokens-gtest gtest)
+    include_directories("${PROJECT_SOURCE_DIR}/vendor/gtest/googletest/include")
 endif()
-include_directories("${PROJECT_SOURCE_DIR}/vendor/gtest/googletest/include")
 
 if(SCITOKENS_EXTERNAL_GTEST)
     set(LIBGTEST "gtest")


### PR DESCRIPTION
Follow-up on my comment on #89.
