### PR TITLE
fix problem with enforcer_test() not returning err_msg

### DIFF
--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -448,7 +448,8 @@ int enforcer_test(const Enforcer enf, const SciToken scitoken, const Acl *acl, c
     }
 
     try {
-        return real_enf->test(*real_scitoken, acl->authz, acl->resource) == true ? 0 : -1;
+        real_enf->test(*real_scitoken, acl->authz, acl->resource);
+        return 0;
     } catch (std::exception &exc) {
         if (err_msg) {*err_msg = strdup(exc.what());}
         return -1;

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -546,15 +546,14 @@ public:
         m_validate_profile = profile;
     }
 
-    bool test(const SciToken &scitoken, const std::string &authz, const std::string &path) {
+    void test(const SciToken &scitoken, const std::string &authz, const std::string &path) {
         reset_state();
         m_test_path = path;
         m_test_authz = authz;
         try {
             m_validator.verify(scitoken);
-            return true;
         } catch (std::runtime_error &) {
-            return false;
+            throw;
         }
     }
 


### PR DESCRIPTION
@atsushi0804 found that enforcer_test() was not returning err_msg correctly and why.
the attached test program shows "(null)" as err_msg.

[scitokens-bug.tgz](https://github.com/scitokens/scitokens-cpp/files/9157900/scitokens-bug.tgz)
