### PR TITLE
Allow the library user to explicitly set the "current" time.

### DIFF
--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -347,6 +347,18 @@ int validator_validate(Validator validator, SciToken scitoken, char **err_msg) {
 }
 
 
+int validator_set_time(Validator validator, time_t now, char **err_msg) {
+    if (validator == nullptr) {
+        if (err_msg) {*err_msg = strdup("Validator may not be a null pointer");}
+        return -1;
+    }
+    auto real_validator = reinterpret_cast<scitokens::Validator*>(validator);
+
+    real_validator->set_now(std::chrono::system_clock::from_time_t(now));
+
+    return 0;
+}
+
 Enforcer enforcer_create(const char *issuer, const char **audience_list, char **err_msg) {
     if (issuer == nullptr) {
         if (err_msg) {*err_msg = strdup("Issuer may not be a null pointer");}
@@ -385,6 +397,19 @@ void enforcer_set_validate_profile(Enforcer enf, SciTokenProfile profile) {
 
     auto real_enf = reinterpret_cast<scitokens::Enforcer*>(enf);
     real_enf->set_validate_profile(static_cast<scitokens::SciToken::Profile>(profile));
+}
+
+
+int enforcer_set_time(Enforcer enf, time_t now, char **err_msg) {
+    if (enf == nullptr) {
+        if (err_msg) {*err_msg = strdup("Enforcer may not be a null pointer");}
+        return -1;
+    }
+    auto real_enf = reinterpret_cast<scitokens::Enforcer*>(enf);
+
+    real_enf->set_now(std::chrono::system_clock::from_time_t(now));
+
+    return 0;
 }
 
 

--- a/src/scitokens.h
+++ b/src/scitokens.h
@@ -5,7 +5,10 @@
  */
 
 #ifdef __cplusplus
+#include <ctime>
 extern "C" {
+#else
+#include <time.h>
 #endif
 
 typedef void * SciTokenKey;
@@ -100,6 +103,12 @@ Validator validator_create();
  */
 void validator_set_token_profile(Validator, SciTokenProfile profile);
 
+/**
+ * Set the time to use with the validator.  Useful if you want to see if the token would
+ * have been valid at some time in the past.
+ */
+int validator_set_time(Validator validator, time_t now, char **err_msg);
+
 int validator_add(Validator validator, const char *claim, StringValidatorFunction validator_func, char **err_msg);
 
 int validator_add_critical_claims(Validator validator, const char **claims, char **err_msg);
@@ -120,6 +129,12 @@ void enforcer_destroy(Enforcer);
  * will be converted to SciTokens 1.0-style authorizations (so, WLCG's storage.read becomes read).
  */
 void enforcer_set_validate_profile(Enforcer, SciTokenProfile profile);
+
+/**
+ * Set the time to use with the enforcer.  Useful if you want to see if the token would
+ * have been valid at some time in the past.
+ */
+int enforcer_set_time(Enforcer enf, time_t now, char **err_msg);
 
 int enforcer_generate_acls(const Enforcer enf, const SciToken scitokens, Acl **acls, char **err_msg);
 

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -6,6 +6,15 @@
 #include <jwt-cpp/jwt.h>
 #include <uuid/uuid.h>
 
+namespace {
+
+struct FixedClock {
+    jwt::date m_now;
+    jwt::date now() const {return m_now;}
+};
+
+}
+
 namespace jwt {
     template<typename json_traits>
     class decoded_jwt;
@@ -267,6 +276,10 @@ class Validator {
     typedef std::map<std::string, std::vector<std::pair<ClaimValidatorFunction, void*>>> ClaimValidatorMap;
 
 public:
+    Validator() : m_now(std::chrono::system_clock::now()) {}
+
+    void set_now(std::chrono::system_clock::time_point now) {m_now = now;}
+
     void verify(const SciToken &scitoken) {
         const jwt::decoded_jwt<jwt::traits::kazuho_picojson> *jwt_decoded = scitoken.m_decoded.get();
         if (!jwt_decoded) {
@@ -343,7 +356,8 @@ public:
         get_public_key_pem(jwt.get_issuer(), key_id, public_pem, algorithm);
         // std::cout << "Public PEM: " << public_pem << std::endl << "Algorithm: " << algorithm << std::endl;
         SciTokenKey key(key_id, algorithm, public_pem, "");
-        auto verifier = jwt::verify()
+
+        auto verifier = jwt::verify<FixedClock, jwt::traits::kazuho_picojson>({m_now})
             .allow_algorithm(key);
 
         verifier.verify(jwt);
@@ -528,6 +542,8 @@ private:
     ClaimStringValidatorMap m_validators;
     ClaimValidatorMap m_claim_validators;
 
+    std::chrono::system_clock::time_point m_now;
+
     std::vector<std::string> m_critical_claims;
     std::vector<std::string> m_allowed_issuers;
 };
@@ -555,6 +571,8 @@ public:
         }
         m_validator.add_critical_claims(critical_claims);
     }
+
+    void set_now(std::chrono::system_clock::time_point now) {m_validator.set_now(now);}
 
     void set_validate_profile(SciToken::Profile profile) {
         m_validate_profile = profile;


### PR DESCRIPTION
For XRootD, we decided that the "time" the session token should be evaluated should be when the session starts and not when the operation is attempted; this allows session authorizations to live longer than the token (this matches how X.509 works -- expiration time is only checked at start).

Hence, at the SciTokens library level we must allow the user to explicitly set the clock backward for token evaluation.

Implementation is rather straightforward - unit test is included.