### PR TITLE
Provide an API enabling explicit manipulation of the keycache for the end user.

### DIFF
--- a/configs/export-symbols
+++ b/configs/export-symbols
@@ -3,6 +3,7 @@ global:
   scitoken*;
   validator*;
   enforcer*;
+  keycache*;
 
 local:
   *;

--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -455,3 +455,65 @@ int enforcer_test(const Enforcer enf, const SciToken scitoken, const Acl *acl, c
     }
     return 0;
 }
+
+
+int keycache_refresh_jwks(const char *issuer, char **err_msg)
+{
+    if (!issuer) {
+        if (err_msg) {*err_msg = strdup("Issuer may not be a null pointer");}
+        return -1;
+    }
+    try {
+        if (!scitokens::Validator::refresh_jwks(issuer)) {
+            if (err_msg) {*err_msg = strdup("Failed to refresh JWKS cache for issuer.");}
+            return -1;
+        }
+    } catch (std::exception &exc) {
+        if (err_msg) {*err_msg = strdup(exc.what());}
+        return -1;
+    }
+    return 0;
+}
+
+
+int keycache_get_cached_jwks(const char *issuer, char **jwks, char **err_msg)
+{
+    if (!issuer) {
+        if (err_msg) {*err_msg = strdup("Issuer may not be a null pointer");}
+        return -1;
+    }
+    if (!jwks) {
+        if (err_msg) {*err_msg = strdup("JWKS output pointer may not be null.");}
+        return -1;
+    }
+    try {
+        *jwks = strdup(scitokens::Validator::get_jwks(issuer).c_str());
+    } catch(std::exception &exc) {
+        if (err_msg) {*err_msg = strdup(exc.what());}
+        return -1;
+    }
+    return 0;
+}
+
+
+int keycache_set_jwks(const char *issuer, const char *jwks, char **err_msg)
+{
+    if (!issuer) {
+        if (err_msg) {*err_msg = strdup("Issuer may not be a null pointer");}
+        return -1;
+    }
+    if (!jwks) {
+        if (err_msg) {*err_msg = strdup("JWKS pointer may not be null.");}
+        return -1;
+    }
+    try {
+        if (!scitokens::Validator::store_jwks(issuer, jwks)) {
+            if (err_msg) {*err_msg = strdup("Failed to set the JWKS cache for issuer.");}
+            return -1;
+        }
+    } catch(std::exception &exc) {
+        if (err_msg) {*err_msg = strdup(exc.what());}
+        return -1;
+    }
+    return 0;
+}

--- a/src/scitokens.h
+++ b/src/scitokens.h
@@ -127,6 +127,39 @@ void enforcer_acl_free(Acl *acls);
 
 int enforcer_test(const Enforcer enf, const SciToken sci, const Acl *acl, char **err_msg);
 
+
+/**
+ * API for explicity managing the key cache.
+ *
+ * This manipulates the keycache for the current eUID.
+ */
+
+
+/**
+ * Refresh the JWKS in the keycache for a given issuer; the refresh will occur
+ * even if the JWKS is not otherwise due for updates.
+ * - Returns 0 on success, nonzero on failure.
+ */
+int keycache_refresh_jwks(const char *issuer, char **err_msg);
+
+/**
+ * Retrieve the JWKS from the keycache for a given issuer.
+ * - Returns 0 if successful, nonzero on failure.
+ * - If the existing JWKS has expired - or does not exist - this does not trigger a new
+ *   download of the JWKS from the issuer.  Instead, it will return a JWKS object with
+ *   an empty set of keys.
+ * - `jwks` is an output variable set to the contents of the JWKS in the key cache.
+ */
+int keycache_get_cached_jwks(const char *issuer, char **jwks, char **err_msg);
+
+/**
+ * Replace any existing key cache entry with one provided by the user.
+ * The expiration and next update time of the user-provided JWKS will utilize
+ * the same rules as a download from an issuer with no explicit cache lifetime directives.
+ * - `jwks` is value that will be set in the cache.
+ */
+int keycache_set_jwks(const char *issuer, const char *jwks, char **err_msg);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -516,10 +516,26 @@ public:
      */
     static bool store_public_ec_key(const std::string &issuer, const std::string &kid, const std::string &key);
 
+    /**
+     * Store the contents of a JWKS for a given issuer.
+     */
+    static bool store_jwks(const std::string &issuer, const std::string &jwks);
+
+    /**
+     * Trigger a refresh of the JWKS or a given issuer.
+     */
+    static bool refresh_jwks(const std::string &issuer);
+
+    /**
+     * Fetch the contents of fa JWKS for a given issuer (do not trigger a refresh).
+     * Will return an empty JWKS if no valid JWKS is available.
+     */
+    static std::string get_jwks(const std::string &issuer);
+
 private:
     void get_public_key_pem(const std::string &issuer, const std::string &kid, std::string &public_pem, std::string &algorithm);
-    void get_public_keys_from_web(const std::string &issuer, picojson::value &keys, int64_t &next_update, int64_t &expires);
-    bool get_public_keys_from_db(const std::string issuer, int64_t now, picojson::value &keys, int64_t &next_update);
+    static void get_public_keys_from_web(const std::string &issuer, picojson::value &keys, int64_t &next_update, int64_t &expires);
+    static bool get_public_keys_from_db(const std::string issuer, int64_t now, picojson::value &keys, int64_t &next_update);
     static bool store_public_keys(const std::string &issuer, const picojson::value &keys, int64_t next_update, int64_t expires);
 
     bool m_validate_all_claims{true};


### PR DESCRIPTION
With this, it should be possible to write simple python scripts for manipulating the keycache:

```
>>> import json
>>> from cffi import FFI
>>> ffi = FFI()
>>> ffi.cdef("""
... void free(void *);
... int keycache_refresh_jwks(const char *issuer, char **err_msg);
... int keycache_get_cached_jwks(const char *issuer, char **jwks, char **err_msg);
... int keycache_set_jwks(const char *issuer, const char *jwks, char **err_msg);
... """)
>>> C = ffi.dlopen(None)
>>> scitokens = ffi.dlopen("release_dir/lib64/libSciTokens.so")
>>> jwks_result = ffi.new("char**", ffi.NULL)
>>> err_msg = ffi.new("char**", ffi.NULL)
>>> scitokens.keycache_get_cached_jwks("https://demo.scitokens.org".encode(), jwks_result, err_msg)
0
>>> json.loads(ffi.string(jwks_result[0]).decode())
{'keys': [{'alg': 'ES256', 'kid': 'key-es256', 'kty': 'EC', 'use': 'sig', 'x': 'ncSCrGTBTXXOhNiAOTwNdPjwRz1hVY4saDNiHQK9Bh4=', 'y': 'sCsFXvx7FAAklwq3CzRCBcghqZOFPB2dKUayS6LY_Lo='}]}
>>> C.free(jwks_result[0])
```

Nifty!

This will allow me write a condor-ce script which injects temporary public keys for a given issuer, allowing the admins to generate an arbitrary token "as", say, CMS which is valid only at that CE.