### PR TITLE
Shorten timeout for public key download (backport)

### DIFF
--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -504,7 +504,7 @@ public:
 
 private:
     void get_public_key_pem(const std::string &issuer, const std::string &kid, std::string &public_pem, std::string &algorithm);
-    void get_public_keys_from_web(const std::string &issuer, picojson::value &keys, int64_t &next_update, int64_t &expires);
+    void get_public_keys_from_web(const std::string &issuer, unsigned timeout, picojson::value &keys, int64_t &next_update, int64_t &expires);
     bool get_public_keys_from_db(const std::string issuer, int64_t now, picojson::value &keys, int64_t &next_update);
     static bool store_public_keys(const std::string &issuer, const picojson::value &keys, int64_t next_update, int64_t expires);
 


### PR DESCRIPTION
While the public key download can fail and have the library fall back on the cached copy, this fallback can take such a long time that the application code (such as the HTCondor-CE) invoking the library times out its current operation and still failing.

So, without this, the fallback succeeds but everything else fails due to timeouts.

For now, we have arbitrarily set the timeout to 30s for the case where the pubkey has expired and 4s for the update check.