### PR TITLE
Avoid retrying for 5 minutes after failed key retrieval (backport)

### DIFF
--- a/src/scitokens_cache.cpp
+++ b/src/scitokens_cache.cpp
@@ -121,7 +121,7 @@ remove_issuer_entry(sqlite3 *db, const std::string &issuer, bool new_transaction
 
 
 bool
-scitokens::Validator::get_public_keys_from_db(const std::string issuer, int64_t now, picojson::value &keys, int64_t &next_update) {
+scitokens::Validator::get_public_keys_from_db(const std::string issuer, int64_t now, picojson::value &keys, int64_t &next_update, int64_t &expires) {
     auto cache_fname = get_cache_file();
     if (cache_fname.size() == 0) {return false;}
 
@@ -177,6 +177,7 @@ scitokens::Validator::get_public_keys_from_db(const std::string issuer, int64_t 
             sqlite3_close(db);
             return false;
         }
+        expires = expiry;
         sqlite3_close(db);
         iter = top_obj.find("next_update");
         if (iter == top_obj.end() || !iter->second.is<int64_t>()) {

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -505,7 +505,7 @@ public:
 private:
     void get_public_key_pem(const std::string &issuer, const std::string &kid, std::string &public_pem, std::string &algorithm);
     void get_public_keys_from_web(const std::string &issuer, unsigned timeout, picojson::value &keys, int64_t &next_update, int64_t &expires);
-    bool get_public_keys_from_db(const std::string issuer, int64_t now, picojson::value &keys, int64_t &next_update);
+    bool get_public_keys_from_db(const std::string issuer, int64_t now, picojson::value &keys, int64_t &next_update, int64_t &expires);
     static bool store_public_keys(const std::string &issuer, const picojson::value &keys, int64_t next_update, int64_t expires);
 
     bool m_validate_all_claims{true};


### PR DESCRIPTION
Without this, a persistent failure in the key retrieval will not be remembered, meaning rapid-fire retries from the client will result in a similar number of key retrieval attempts.

This causes the next_update to be set forward by 5 minutes after each failure.