### PR TITLE
Add a Linter action to the GitHub workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: LLVM
+IndentWidth: 4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -41,6 +41,6 @@ jobs:
           commit: true 
           continue_on_error: false
           git_email: github.event.commits[0].author.name # Uses the author's git email instead of the default git email associated with the action ("lint-action@samuelmeuli.com")
-          #clang_format_args: # Any additional arguments for clang_format
+          clang_format_args: -style=file # Any additional arguments for clang_format
 
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,46 @@
+name: Lint
+
+# Linter Action documentation at https://github.com/marketplace/actions/lint-action
+
+# One thing to note is that this action is currently configured automatically fix and re-push the linted code to the repo on a pull request.
+# Because the github token used for authenticating this commit comes from the upstream repo (ie scitokens/scitokens-cpp), those linter changes will not be pushed
+# to the fork that is providing the pull request. A manual git fetch will have to be run by the fork after the PR is merged to update the fork to the linted code.
+# The linter does not have authorization to lint any code in the repo's .github/workflows/ directory.
+
+# If the linter fails, the PR can still be completed, but none of the linter changes will be made.
+
+on:
+  # push: # Can specify more circumstances under which to run the linter. 
+  #   branches: # Not specifying input to "branches:" causes the action to run on push for all branches.            
+
+  # Trigger the workflow on pull request,
+  # but only for master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  run-linters:
+    name: Run linters
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Install ClangFormat
+        run: sudo apt-get install -y clang-format
+
+      - name: Run linters
+        uses: wearerequired/lint-action@v2
+        with:
+          github_token: ${{ secrets.github_token }} # For providing the commit authorization for the auto_fix feature
+          clang_format: true
+          clang_format_auto_fix: true
+          auto_fix: true
+          commit: true 
+          continue_on_error: false
+          git_email: github.event.commits[0].author.name # Uses the author's git email instead of the default git email associated with the action ("lint-action@samuelmeuli.com")
+          #clang_format_args: # Any additional arguments for clang_format
+
+


### PR DESCRIPTION
This commit adds a linter action that can automatically lint code in the repo. It's currently configured to analyze and automatically lint code whenever a PR is merged with master. The goal is to establish a cleaner and more structured code base. After the initial lint, the linter should only touch new/modified files.