### PR TITLE
Add configuration API to set keycache update/expiration intervals

### DIFF
--- a/configs/export-symbols
+++ b/configs/export-symbols
@@ -4,7 +4,8 @@ global:
   validator*;
   enforcer*;
   keycache*;
-
+  config*;
+  
 local:
   *;
 };

--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -1,8 +1,7 @@
-
-#include <exception>
-
-#include <string.h>
 #include <atomic>
+#include <exception>
+#include <string.h>
+
 
 #include "scitokens.h"
 #include "scitokens_internal.h"
@@ -11,7 +10,7 @@
  * GLOBALS
  */
 std::atomic_int configurer::Configuration::m_next_update_delta{600};
-std::atomic_int configurer::Configuration::m_expiry_delta{4*24*3600};
+std::atomic_int configurer::Configuration::m_expiry_delta{4 * 24 * 3600};
 
 SciTokenKey scitoken_key_create(const char *key_id, const char *alg,
                                 const char *public_contents,
@@ -972,7 +971,7 @@ int config_set_int(const char *key, int value, char **err_msg) {
     }
 
     if (_key == "keycache.expiration_interval_s") {
-        if (value <0 ) {
+        if (value < 0 ) {
             if (err_msg) {
                 *err_msg = strdup("Expiry interval must be positive.");
             }

--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -2,9 +2,16 @@
 #include <exception>
 
 #include <string.h>
+#include <atomic>
 
 #include "scitokens.h"
 #include "scitokens_internal.h"
+
+/**
+ * GLOBALS
+ */
+std::atomic_int configurer::Configuration::m_next_update_delta{600};
+std::atomic_int configurer::Configuration::m_expiry_delta{4*24*3600};
 
 SciTokenKey scitoken_key_create(const char *key_id, const char *alg,
                                 const char *public_contents,
@@ -941,4 +948,70 @@ int keycache_set_jwks(const char *issuer, const char *jwks, char **err_msg) {
         return -1;
     }
     return 0;
+}
+
+int config_set_int(const char *key, int value, char **err_msg) {
+    if (!key) {
+        if (err_msg) {
+            *err_msg = strdup("A key must be provided.");
+        }
+        return -1;
+    }
+
+    std::string _key = key;
+
+    if (_key == "keycache.update_interval_s") {
+        if (value < 0) {
+            if (err_msg) {
+                *err_msg = strdup("Update interval must be positive.");
+            }
+            return -1;
+        }
+        configurer::Configuration::set_next_update_delta(value);
+        return 0;
+    }
+
+    if (_key == "keycache.expiration_interval_s") {
+        if (value <0 ) {
+            if (err_msg) {
+                *err_msg = strdup("Expiry interval must be positive.");
+            }
+            return -1;
+        }
+        configurer::Configuration::set_expiry_delta(value);
+        return 0;
+    }
+
+    else {
+        if (err_msg) {
+            *err_msg = strdup("Key not recognized.");
+        }
+        return -1;
+    }
+}
+
+int config_get_int(const char *key, char **err_msg) {
+    if (!key) {
+        if (err_msg) {
+            *err_msg = strdup("A key must be provided.");
+        }
+        return -1;
+    }
+
+    std::string _key = key;
+
+    if (_key == "keycache.update_interval_s") {
+        return configurer::Configuration::get_next_update_delta();
+    }
+
+    if (_key == "keycache.expiration_interval_s") {
+        return configurer::Configuration::get_expiry_delta();
+    }
+
+    else {
+        if (err_msg) {
+            *err_msg = strdup("Key not recognized.");
+        }
+        return -1;
+    }
 }

--- a/src/scitokens.h
+++ b/src/scitokens.h
@@ -19,6 +19,7 @@ typedef void *SciToken;
 typedef void *Validator;
 typedef void *Enforcer;
 typedef void *SciTokenStatus;
+typedef void *Configuration;
 
 typedef int (*StringValidatorFunction)(const char *value, char **err_msg);
 typedef struct Acl_s {
@@ -288,6 +289,26 @@ int keycache_get_cached_jwks(const char *issuer, char **jwks, char **err_msg);
  * - `jwks` is value that will be set in the cache.
  */
 int keycache_set_jwks(const char *issuer, const char *jwks, char **err_msg);
+
+/**
+ * API for managing scitokens configuration parameters.
+ */
+
+/**
+ * Update scitokens parameters.
+ * Takes in key/value pairs and assigns the input value to whatever
+ * configuration variable is indicated by the key.
+ * Returns 0 on success, and non-zero for invalid keys or values.
+ */
+int config_set_int(const char *key, int value, char **err_msg);
+
+/**
+ * Get current scitokens parameters.
+ * Returns the value associated with the supplied input key on success, and -1
+ * on failure This assumes there are no keys for which a negative return value
+ * is permissible.
+ */
+int config_get_int(const char *key, char **err_msg);
 
 #ifdef __cplusplus
 }

--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -546,11 +546,6 @@ std::string normalize_absolute_path(const std::string &path) {
     return result.empty() ? "/" : result;
 }
 
-void get_default_expiry_time(int &next_update_delta, int &expiry_delta) {
-    next_update_delta = 600;
-    expiry_delta = 4 * 24 * 3600;
-}
-
 } // namespace
 
 void SciToken::deserialize(const std::string &data,
@@ -695,8 +690,9 @@ std::unique_ptr<AsyncStatus> Validator::get_public_keys_from_web_continue(
         // TODO: take expiration time from the cache-control header in the
         // response.
 
-        int next_update_delta, expiry_delta;
-        get_default_expiry_time(next_update_delta, expiry_delta);
+        int next_update_delta =
+            configurer::Configuration::get_next_update_delta();
+        int expiry_delta = configurer::Configuration::get_expiry_delta();
         status->m_next_update = now + next_update_delta;
         status->m_expires = now + expiry_delta;
         status->m_keys = json_obj;
@@ -738,8 +734,8 @@ bool Validator::store_jwks(const std::string &issuer,
     picojson::value jwks;
     std::string err = picojson::parse(jwks, jwks_str);
     auto now = std::time(NULL);
-    int next_update_delta, expiry_delta;
-    get_default_expiry_time(next_update_delta, expiry_delta);
+    int next_update_delta = configurer::Configuration::get_next_update_delta();
+    int expiry_delta = configurer::Configuration::get_expiry_delta();
     int64_t next_update = now + next_update_delta, expires = now + expiry_delta;
     if (!err.empty()) {
         throw JsonException(err);
@@ -980,8 +976,8 @@ bool scitokens::Validator::store_public_ec_key(const std::string &issuer,
     picojson::value top_value(top_obj);
 
     auto now = std::time(NULL);
-    int next_update_delta, expiry_delta;
-    get_default_expiry_time(next_update_delta, expiry_delta);
+    int next_update_delta = configurer::Configuration::get_next_update_delta();
+    int expiry_delta = configurer::Configuration::get_expiry_delta();
     return store_public_keys(issuer, top_value, now + next_update_delta,
                              now + expiry_delta);
 }

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -42,7 +42,6 @@ class Configuration {
         m_expiry_delta = _expiry_delta;
     }
     static int get_expiry_delta() { return m_expiry_delta; }
-    
   private:
     static std::atomic_int m_next_update_delta;
     static std::atomic_int m_expiry_delta;

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <unordered_map>
 
+#include <atomic>
 #include <curl/curl.h>
 #include <jwt-cpp/jwt.h>
 #include <uuid/uuid.h>
@@ -28,6 +29,25 @@ namespace traits {
 struct kazuho_picojson;
 }
 } // namespace jwt
+
+namespace configurer {
+class Configuration {
+  public:
+    Configuration() {}
+    static void set_next_update_delta(int _next_update_delta) {
+        m_next_update_delta = _next_update_delta;
+    }
+    static int get_next_update_delta() { return m_next_update_delta; }
+    static void set_expiry_delta(int _expiry_delta) {
+        m_expiry_delta = _expiry_delta;
+    }
+    static int get_expiry_delta() { return m_expiry_delta; }
+    
+  private:
+    static std::atomic_int m_next_update_delta;
+    static std::atomic_int m_expiry_delta;
+};
+} // namespace configurer
 
 namespace scitokens {
 


### PR DESCRIPTION
Prior to this feature, the keycache was hard-coded to update every 10m and expire every 4d. This addition allows administrators to explicitly set these parameters to optimize behavior of the keycache in their systems.