### PR TITLE
Improve error messages when metadata fetch/parse fails

### DIFF
--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -84,6 +84,7 @@ class SimpleCurlGet {
     GetStatus perform_continue();
     int perform(const std::string &url, time_t expiry_time);
     void get_data(char *&buffer, size_t &len);
+    std::string get_url() const;
 
     long get_timeout_ms() const { return m_timeout_ms; }
     int get_max_fd() const { return m_max_fd; }


### PR DESCRIPTION
When the metadata file is corrupt on the issuer, it's difficult to see what / where the failure occurred.  This includes the URL of the problem (or problem JSON) in the exception message.