### PR TITLE
Cache location config

### DIFF
--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -1,6 +1,7 @@
 #include <atomic>
 #include <exception>
 #include <string.h>
+#include <sys/stat.h>
 
 
 #include "scitokens.h"
@@ -9,8 +10,13 @@
 /**
  * GLOBALS
  */
+
+// Cache timeout config
 std::atomic_int configurer::Configuration::m_next_update_delta{600};
 std::atomic_int configurer::Configuration::m_expiry_delta{4 * 24 * 3600};
+
+// SciTokens cache home config
+std::string configurer::Configuration::m_cache_home{""};
 
 SciTokenKey scitoken_key_create(const char *key_id, const char *alg,
                                 const char *public_contents,
@@ -958,7 +964,6 @@ int config_set_int(const char *key, int value, char **err_msg) {
     }
 
     std::string _key = key;
-
     if (_key == "keycache.update_interval_s") {
         if (value < 0) {
             if (err_msg) {
@@ -970,7 +975,7 @@ int config_set_int(const char *key, int value, char **err_msg) {
         return 0;
     }
 
-    if (_key == "keycache.expiration_interval_s") {
+    else if (_key == "keycache.expiration_interval_s") {
         if (value < 0 ) {
             if (err_msg) {
                 *err_msg = strdup("Expiry interval must be positive.");
@@ -998,12 +1003,11 @@ int config_get_int(const char *key, char **err_msg) {
     }
 
     std::string _key = key;
-
     if (_key == "keycache.update_interval_s") {
         return configurer::Configuration::get_next_update_delta();
     }
 
-    if (_key == "keycache.expiration_interval_s") {
+    else if (_key == "keycache.expiration_interval_s") {
         return configurer::Configuration::get_expiry_delta();
     }
 
@@ -1014,3 +1018,56 @@ int config_get_int(const char *key, char **err_msg) {
         return -1;
     }
 }
+
+int config_set_str(const char *key, const char *value, char **err_msg) {
+    if (!key) {
+        if (err_msg) {
+            *err_msg = strdup("A key must be provided.");
+        }
+        return -1;
+    }
+
+    std::string _key = key;
+    if (_key == "keycache.cache_home") {
+        auto rp = configurer::Configuration::set_cache_home(value);
+        if (!rp.first) { // There was an error, pass rp.second to err_msg
+            if (err_msg) {
+                *err_msg = strdup(rp.second.c_str());
+            }
+            return -1;
+        }
+    }
+
+    else {
+        if (err_msg) {
+            *err_msg = strdup("Key not recognized.");
+        }
+        return -1;
+    }
+    return 0;
+}
+
+int config_get_str(const char *key, char **output, char **err_msg) {
+    if (!key) {
+        if (err_msg) {
+            *err_msg = strdup("A key must be provided.");
+        }
+        return -1;
+    }
+
+    std::string _key = key;
+    if (_key == "keycache.cache_home") {
+        *output = strdup(configurer::Configuration::get_cache_home().c_str());
+    }
+
+    else {
+        if (err_msg) {
+            *err_msg = strdup("Key not recognized.");
+        }
+        return -1;
+    }
+    return 0;
+}
+
+
+

--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -1068,6 +1068,3 @@ int config_get_str(const char *key, char **output, char **err_msg) {
     }
     return 0;
 }
-
-
-

--- a/src/scitokens.h
+++ b/src/scitokens.h
@@ -295,7 +295,7 @@ int keycache_set_jwks(const char *issuer, const char *jwks, char **err_msg);
  */
 
 /**
- * Update scitokens parameters.
+ * Update scitokens int parameters.
  * Takes in key/value pairs and assigns the input value to whatever
  * configuration variable is indicated by the key.
  * Returns 0 on success, and non-zero for invalid keys or values.
@@ -303,12 +303,25 @@ int keycache_set_jwks(const char *issuer, const char *jwks, char **err_msg);
 int config_set_int(const char *key, int value, char **err_msg);
 
 /**
- * Get current scitokens parameters.
+ * Get current scitokens int parameters.
  * Returns the value associated with the supplied input key on success, and -1
  * on failure This assumes there are no keys for which a negative return value
  * is permissible.
  */
 int config_get_int(const char *key, char **err_msg);
+
+/**
+ * Set current scitokens str parameters.
+ * Returns 0 on success, nonzero on failure
+ */
+int config_set_str(const char *key, const char *value, char **err_msg);
+
+/**
+ * Get current scitokens str parameters.
+ * Returns 0 on success, nonzero on failure, and populates the value associated
+ * with the input key to output.
+ */
+int config_get_str(const char *key, char **output, char **err_msg);
 
 #ifdef __cplusplus
 }

--- a/src/scitokens_cache.cpp
+++ b/src/scitokens_cache.cpp
@@ -42,9 +42,9 @@ void initialize_cachedb(const std::string &keycache_file) {
 
 /**
  * Get the Cache file location
- *
- *  1. $XDG_CACHE_HOME
- *  2. .cache subdirectory of home directory as returned by the password
+ *  1. User-defined through config api
+ *  2. $XDG_CACHE_HOME
+ *  3. .cache subdirectory of home directory as returned by the password
  * database
  */
 std::string get_cache_file() {
@@ -64,7 +64,16 @@ std::string get_cache_file() {
         home_dir += "/.cache";
     }
 
-    std::string cache_dir(xdg_cache_home ? xdg_cache_home : home_dir.c_str());
+    // Figure out where to plop the cache based on priority
+    std::string cache_dir;
+    std::string configured_cache_dir = configurer::Configuration::get_cache_home();
+    if (configured_cache_dir.length() > 0) { // The variable has been configured
+        cache_dir = configured_cache_dir;
+    }
+    else {
+        cache_dir = xdg_cache_home ? xdg_cache_home : home_dir.c_str();
+    }
+
     if (cache_dir.size() == 0) {
         return "";
     }

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -42,9 +42,16 @@ class Configuration {
         m_expiry_delta = _expiry_delta;
     }
     static int get_expiry_delta() { return m_expiry_delta; }
+    static std::pair<bool, std::string> set_cache_home(const std::string cache_home);
+    static std::string get_cache_home();
   private:
     static std::atomic_int m_next_update_delta;
     static std::atomic_int m_expiry_delta;
+    static std::string m_cache_home;
+    static bool check_dir(const std::string dir_path);
+    static bool mkdir_and_parents_if_needed(const std::string dir_path);
+    static std::vector<std::string> path_split(const std::string dir_path);
+
 };
 } // namespace configurer
 

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -51,7 +51,6 @@ class Configuration {
     static bool check_dir(const std::string dir_path);
     static bool mkdir_and_parents_if_needed(const std::string dir_path);
     static std::vector<std::string> path_split(const std::string dir_path);
-
 };
 } // namespace configurer
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -272,15 +272,6 @@ TEST_F(KeycacheTest, RefreshExpiredTest) {
     EXPECT_EQ(jwks_str, "{\"keys\": []}");
 }
 
-// TEST_F(KeycacheTest, SetGetCacheHomeTest) {
-//     char *err_msg, *jwks;
-//     std::string key = "keycache.cache_home";
-//     std::string cache_path = "/workspaces/scitokens-cpp/my_config";
-//     auto rv = config_set_str(key.c_str(), cache_path.c_str(), &err_msg);
-
-//     // Now create the cache there
-// }
-
 class SerializeTest : public ::testing::Test {
   protected:
     void SetUp() override {


### PR DESCRIPTION
See Issue #118 

There has been desire to create a method by which users can configure
where to store the key cache without setting the env var `$XDG_CACHE_HOME`
or relying on the user to have a home dir. This is especially relevant
in cases where the library is embedded in a daemon (e.g. XRootD or HTCondor)
that may have a preferencial key cache location. This commit adds a familiar
`config_set_str` and `config_get_str` API for passing a new cache home to
the library through the use of the `keycache.cache_home` key.

As with `config_set_int` and `config_get_int`, these new functions can be
easily updated in the future as the project develops and new
configuration keys are desired. This would entail adding a new check for
the desired key and the logic to handle any values associated with that key.

Some comments/questions:
- Do we need to add a mutex/lock to any of this configuration?
- Are we interested in more robust error handling in the case that
   a garbage path is provided to the configuration API? I made the
   assumption that we weren't, since there were no checks on what
   was supplied by `XDG_CACHE_HOME`. Currently, the implementation
   tries to create whatever directory is passed through the API if it doesn't
   exist, but this could break if the user has insufficient permissions to
   write to that location, or the path contains invalid chars (and probably 
   some other things I'm not thinking of).
- I lumped the directory handling/creation methods into the configuration
   class. Would we rather those be moved to a new class dedicated to this
   type of functionality? I noticed in testing that if `XDG_CACHE_HOME` is 
   set to a directory that doesn't already exist, the current code will fail if 
   any parent dirs need to be created. The new config API attempts to create
   those parent dirs, so maybe a stub class to handle these types of things 
   would be useful.
