### PR TITLE
Add wrapper to throw compiler warning for deprecated funcs

### DIFF
--- a/src/scitokens.h
+++ b/src/scitokens.h
@@ -14,6 +14,21 @@ extern "C" {
 #include <time.h>
 #endif
 
+// Set up a wrapper macro to warn compiler of soon-to-be-deprecated functions
+#if __cplusplus >= 201402L
+    #if defined(__has_cpp_attribute)
+        #if __has_cpp_attribute(deprecated)
+            #define DEPRECATION_WARNING(msg, func) [[deprecated(msg)]] func
+        #endif
+    #endif
+#else
+    #ifdef __GNUC__
+        #define DEPRECATION_WARNING(msg, func) func __attribute__ ((deprecated(msg)))
+    #elif defined(_MSC_VER)
+        #define DEPRECATION_WARNING(msg, func) __declspec(deprecated(msg)) func
+    #endif
+#endif
+
 typedef void *SciTokenKey;
 typedef void *SciToken;
 typedef void *Validator;
@@ -294,8 +309,9 @@ int keycache_set_jwks(const char *issuer, const char *jwks, char **err_msg);
  * APIs for managing scitokens configuration parameters.
  */
 
-// On its way to deprecation
-int config_set_int(const char *key, int value, char **err_msg);
+
+// On its way to deprecation. API wrapped in deprecation warning
+DEPRECATION_WARNING("Use scitoken_ prefixed version instead", int config_set_int(const char *key, int value, char **err_msg));
 
 /**
  * Update scitokens int parameters.
@@ -305,8 +321,8 @@ int config_set_int(const char *key, int value, char **err_msg);
  */
 int scitoken_config_set_int(const char *key, int value, char **err_msg);
 
-// on its way to deprecation
-int config_get_int(const char *key, char **err_msg);
+// On its way to deprecation. API wrapped in deprecation warning
+DEPRECATION_WARNING("Use scitoken_ prefixed version instead", int config_get_int(const char *key, char **err_msg));
 
 /**
  * Get current scitokens int parameters.


### PR DESCRIPTION
In order to keep the `scitokens.h` header backwards compatible with older versions of C/C++ while still providing support for compiler warnings when a deprecated function is used, I set up a macro wrapper that checks for compiler support of the attribute and throws a warning when a deprecated function is used.

I was aiming for broad compiler compatibility. Let me know if there's anything I can change.