### PR TITLE
scitokens_internal: catch matching exception type after jwt-cpp update

### DIFF
--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -152,8 +152,9 @@ class SciTokenKey {
           m_private(private_contents) {}
 
     std::string serialize(jwt::builder<jwt::traits::kazuho_picojson> &builder) {
-        std::error_code ec;
-        builder.set_key_id(m_kid);
+        if (m_kid != "none") {
+            builder.set_key_id(m_kid);
+        }
         return builder.sign(*this);
     }
 

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -497,10 +497,8 @@ class Validator {
         std::string algorithm;
         // Key id is optional in the RFC, set to blank if it doesn't exist
         std::string key_id;
-        try {
+        if (jwt.has_key_id()) {
             key_id = jwt.get_key_id();
-        } catch (const jwt::error::claim_not_present_exception &) {
-            // Don't do anything, key_id is empty, as it should be.
         }
         auto status =
             get_public_key_pem(jwt.get_issuer(), key_id, public_pem, algorithm);

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -499,7 +499,7 @@ class Validator {
         std::string key_id;
         try {
             key_id = jwt.get_key_id();
-        } catch (const std::runtime_error &) {
+        } catch (const jwt::error::claim_not_present_exception &) {
             // Don't do anything, key_id is empty, as it should be.
         }
         auto status =

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -701,9 +701,9 @@ class SerializeNoKidTest : public ::testing::Test {
   protected:
     void SetUp() override {
         char *err_msg;
-        m_key = KeyPtr(
-            scitoken_key_create("none", "ES256", ec_public, ec_private, &err_msg),
-            scitoken_key_destroy);
+        m_key = KeyPtr(scitoken_key_create("none", "ES256", ec_public,
+                                           ec_private, &err_msg),
+                       scitoken_key_destroy);
         ASSERT_TRUE(m_key.get() != nullptr);
 
         m_token = TokenPtr(scitoken_create(m_key.get()), scitoken_destroy);


### PR DESCRIPTION
After updating the vendored jwt-cpp version in:
 a8c597775f44ad2fa0f7bde8d186aca9466757ab
the exception type if a claim is not found has changed, breaking the "no kid claim" use case.

Adapt the code to catch the new exception type.

This essentially broke:
https://github.com/scitokens/scitokens-cpp/pull/55

@djw8605 Can you think of a good test we could add to ensure this issue does not reappear? 