### PR TITLE
Test failures and compiler warnings

### DIFF
--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -978,9 +978,9 @@ bool scitokens::Validator::store_public_ec_key(const std::string &issuer,
     auto x_num = BN_num_bytes(x_bignum.get());
     auto y_num = BN_num_bytes(y_bignum.get());
     std::vector<unsigned char> x_bin;
-    x_bin.reserve(x_num);
+    x_bin.resize(x_num);
     std::vector<unsigned char> y_bin;
-    y_bin.reserve(y_num);
+    y_bin.resize(y_num);
     BN_bn2bin(x_bignum.get(), &x_bin[0]);
     BN_bn2bin(y_bignum.get(), &y_bin[0]);
     std::string x_str(reinterpret_cast<char *>(&x_bin[0]), x_num);

--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -630,7 +630,7 @@ Validator::get_public_keys_from_web(const std::string &issuer,
     auto cget_status = status->m_cget->perform_start(openid_metadata);
     status->m_continue_fetch = true;
     if (!cget_status.m_done) {
-        return std::move(status);
+        return status;
     }
     return get_public_keys_from_web_continue(std::move(status));
 }
@@ -744,7 +744,6 @@ std::string Validator::get_jwks(const std::string &issuer) {
 }
 
 bool Validator::refresh_jwks(const std::string &issuer) {
-    int64_t next_update, expires;
     picojson::value keys;
     std::unique_ptr<scitokens::AsyncStatus> status = get_public_keys_from_web(
         issuer, internal::SimpleCurlGet::extended_timeout);

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -670,7 +670,7 @@ class Validator {
         }
         std::unique_ptr<AsyncStatus> result(new AsyncStatus());
         result->m_done = true;
-        return std::move(result);
+        return result;
     }
 
     void add_critical_claims(const std::vector<std::string> &claims) {

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -439,7 +439,6 @@ TEST_F(SerializeTest, FailDeserializeAsyncTest) {
 }
 
 TEST_F(SerializeTest, ExplicitTime) {
-    time_t now = time(NULL);
     char *err_msg = nullptr;
 
     scitoken_set_serialize_profile(m_token.get(), SciTokenProfile::WLCG_1_0);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -39,12 +39,12 @@ TEST(SciTokenTest, CreateToken) {
 }
 
 TEST(SciTokenTest, SignToken) {
-    char *err_msg;
+    char *err_msg = nullptr;
 
     std::unique_ptr<void, decltype(&scitoken_key_destroy)> mykey(
         scitoken_key_create("1", "ES256", ec_public, ec_private, &err_msg),
         scitoken_key_destroy);
-    ASSERT_TRUE(mykey.get() != nullptr);
+    ASSERT_TRUE(mykey.get() != nullptr) << err_msg;
 
     std::unique_ptr<void, decltype(&scitoken_destroy)> mytoken(
         scitoken_create(mykey.get()), scitoken_destroy);
@@ -52,11 +52,11 @@ TEST(SciTokenTest, SignToken) {
 
     auto rv = scitoken_set_claim_string(
         mytoken.get(), "iss", "https://demo.scitokens.org/gtest", &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     char *value;
     rv = scitoken_serialize(mytoken.get(), &value, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     EXPECT_TRUE(value != nullptr);
     std::unique_ptr<char, decltype(&free)> value_ptr(value, free);
 
@@ -68,10 +68,10 @@ class KeycacheTest : public ::testing::Test {
     std::string demo_scitokens_url = "https://demo.scitokens.org";
 
     void SetUp() override {
-        char *err_msg;
+        char *err_msg = nullptr;
         auto rv = keycache_set_jwks(demo_scitokens_url.c_str(),
                                     demo_scitokens.c_str(), &err_msg);
-        ASSERT_TRUE(rv == 0);
+        ASSERT_TRUE(rv == 0) << err_msg;
     }
 
     // Reference copy of the keys at https://demo.scitokens.org/oauth2/certs;
@@ -113,14 +113,14 @@ TEST_F(KeycacheTest, RefreshTest) {
 }
 
 TEST_F(KeycacheTest, RefreshInvalid) {
-    char *err_msg, *jwks;
+    char *err_msg = nullptr, *jwks;
     auto rv =
         keycache_refresh_jwks("https://demo.scitokens.org/invalid", &err_msg);
     ASSERT_FALSE(rv == 0);
 
     rv = keycache_get_cached_jwks("https://demo.scitokens.org/invalid", &jwks,
                                   &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     ASSERT_TRUE(jwks != nullptr);
     std::string jwks_str(jwks);
     free(jwks);
@@ -129,20 +129,20 @@ TEST_F(KeycacheTest, RefreshInvalid) {
 }
 
 TEST_F(KeycacheTest, GetInvalid) {
-    char *err_msg, *jwks;
+    char *err_msg = nullptr, *jwks;
     auto rv = keycache_get_cached_jwks("https://demo.scitokens.org/unknown",
                                        &jwks, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     ASSERT_TRUE(jwks != nullptr);
     std::string jwks_str(jwks);
     free(jwks);
 }
 
 TEST_F(KeycacheTest, GetTest) {
-    char *err_msg, *jwks;
+    char *err_msg = nullptr, *jwks;
     auto rv =
         keycache_get_cached_jwks(demo_scitokens_url.c_str(), &jwks, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     ASSERT_TRUE(jwks != nullptr);
     std::string jwks_str(jwks);
     free(jwks);
@@ -151,14 +151,14 @@ TEST_F(KeycacheTest, GetTest) {
 }
 
 TEST_F(KeycacheTest, SetGetTest) {
-    char *err_msg;
+    char *err_msg = nullptr;
     auto rv = keycache_set_jwks(demo_scitokens_url.c_str(),
                                 demo_scitokens2.c_str(), &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     char *jwks;
     rv = keycache_get_cached_jwks(demo_scitokens_url.c_str(), &jwks, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     ASSERT_TRUE(jwks != nullptr);
     std::string jwks_str(jwks);
     free(jwks);
@@ -170,7 +170,7 @@ TEST_F(KeycacheTest, SetGetConfiguredCacheHome) {
     // Set cache home
     char cache_path[FILENAME_MAX];
     ASSERT_TRUE(getcwd(cache_path, sizeof(cache_path)) != nullptr); // Side effect gets cwd
-    char *err_msg;
+    char *err_msg = nullptr;
     std::string key = "keycache.cache_home";
 
     auto rv = scitoken_config_set_str(key.c_str(), cache_path, &err_msg);
@@ -184,7 +184,7 @@ TEST_F(KeycacheTest, SetGetConfiguredCacheHome) {
     // Fetch the cached jwks from the new cache home
     char *jwks;
     rv = keycache_get_cached_jwks(demo_scitokens_url.c_str(), &jwks, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     ASSERT_TRUE(jwks != nullptr);
     std::string jwks_str(jwks);
     free(jwks);
@@ -204,7 +204,7 @@ TEST_F(KeycacheTest, SetGetConfiguredCacheHome) {
 }
 
 TEST_F(KeycacheTest, InvalidConfigKeyTest) {
-    char *err_msg;
+    char *err_msg = nullptr;
     int new_update_interval = 400;
     std::string key = "invalid key";
     auto rv =
@@ -217,31 +217,31 @@ TEST_F(KeycacheTest, InvalidConfigKeyTest) {
 }
 
 TEST_F(KeycacheTest, SetGetUpdateTest) {
-    char *err_msg;
+    char *err_msg = nullptr;
     int new_update_interval = 400;
     std::string key = "keycache.update_interval_s";
     auto rv =
         scitoken_config_set_int(key.c_str(), new_update_interval, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     rv = scitoken_config_get_int(key.c_str(), &err_msg);
-    EXPECT_EQ(rv, new_update_interval);
+    EXPECT_EQ(rv, new_update_interval) << err_msg;
 }
 
 TEST_F(KeycacheTest, SetGetExpirationTest) {
-    char *err_msg;
+    char *err_msg = nullptr;
     int new_expiration_interval = 2 * 24 * 3600;
     std::string key = "keycache.expiration_interval_s";
     auto rv =
         scitoken_config_set_int(key.c_str(), new_expiration_interval, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     rv = scitoken_config_get_int(key.c_str(), &err_msg);
-    EXPECT_EQ(rv, new_expiration_interval);
+    EXPECT_EQ(rv, new_expiration_interval) << err_msg;
 }
 
 TEST_F(KeycacheTest, SetInvalidUpdateTest) {
-    char *err_msg;
+    char *err_msg = nullptr;
     int new_update_interval = -1;
     std::string key = "keycache.update_interval_s";
     auto rv =
@@ -250,7 +250,7 @@ TEST_F(KeycacheTest, SetInvalidUpdateTest) {
 }
 
 TEST_F(KeycacheTest, SetInvalidExpirationTest) {
-    char *err_msg;
+    char *err_msg = nullptr;
     int new_expiration_interval = -2 * 24 * 3600;
     std::string key = "keycache.expiration_interval_s";
     auto rv =
@@ -259,20 +259,20 @@ TEST_F(KeycacheTest, SetInvalidExpirationTest) {
 }
 
 TEST_F(KeycacheTest, RefreshExpiredTest) {
-    char *err_msg, *jwks;
+    char *err_msg = nullptr, *jwks;
     int new_expiration_interval = 0;
     std::string key = "keycache.expiration_interval_s";
     auto rv =
         scitoken_config_set_int(key.c_str(), new_expiration_interval, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     rv = keycache_refresh_jwks(demo_scitokens_url.c_str(), &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     sleep(1);
 
     rv = keycache_get_cached_jwks(demo_scitokens_url.c_str(), &jwks, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     ASSERT_TRUE(jwks != nullptr);
     std::string jwks_str(jwks);
     free(jwks);
@@ -283,22 +283,22 @@ TEST_F(KeycacheTest, RefreshExpiredTest) {
 class SerializeTest : public ::testing::Test {
   protected:
     void SetUp() override {
-        char *err_msg;
+        char *err_msg = nullptr;
         m_key = KeyPtr(
             scitoken_key_create("1", "ES256", ec_public, ec_private, &err_msg),
             scitoken_key_destroy);
-        ASSERT_TRUE(m_key.get() != nullptr);
+        ASSERT_TRUE(m_key.get() != nullptr) << err_msg;
 
         m_token = TokenPtr(scitoken_create(m_key.get()), scitoken_destroy);
         ASSERT_TRUE(m_token.get() != nullptr);
 
         auto rv = scitoken_set_claim_string(
             m_token.get(), "iss", "https://demo.scitokens.org/gtest", &err_msg);
-        ASSERT_TRUE(rv == 0);
+        ASSERT_TRUE(rv == 0) << err_msg;
 
         rv = scitoken_store_public_ec_key("https://demo.scitokens.org/gtest",
                                           "1", ec_public, &err_msg);
-        ASSERT_TRUE(rv == 0);
+        ASSERT_TRUE(rv == 0) << err_msg;
 
         scitoken_set_lifetime(m_token.get(), 60);
 
@@ -312,7 +312,7 @@ class SerializeTest : public ::testing::Test {
         groups[1] = group1;
         rv = scitoken_set_claim_string_list(m_token.get(), "groups", groups,
                                             &err_msg);
-        ASSERT_TRUE(rv == 0);
+        ASSERT_TRUE(rv == 0) << err_msg;
 
         m_read_token.reset(scitoken_create(nullptr));
         ASSERT_TRUE(m_read_token.get() != nullptr);
@@ -335,17 +335,17 @@ TEST_F(SerializeTest, VerifyTest) {
 
     char *token_value = nullptr;
     auto rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     std::unique_ptr<char, decltype(&free)> token_value_ptr(token_value, free);
 
     rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr,
                                  &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     char *value;
     rv = scitoken_get_claim_string(m_read_token.get(), "iss", &value, &err_msg);
     ASSERT_TRUE(value != nullptr);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     std::unique_ptr<char, decltype(&free)> value_ptr(value, free);
     EXPECT_STREQ(value, "https://demo.scitokens.org/gtest");
 
@@ -361,7 +361,7 @@ TEST_F(SerializeTest, TestStringList) {
     char **value;
     auto rv = scitoken_get_claim_string_list(m_token.get(), "groups", &value,
                                              &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     ASSERT_TRUE(value != nullptr);
 
     ASSERT_TRUE(value[0] != nullptr);
@@ -380,18 +380,18 @@ TEST_F(SerializeTest, VerifyWLCGTest) {
     char *token_value = nullptr;
     scitoken_set_serialize_profile(m_token.get(), SciTokenProfile::WLCG_1_0);
     auto rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     std::unique_ptr<char, decltype(&free)> token_value_ptr(token_value, free);
 
     // Accepts any profile.
     rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr,
                                  &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     char *value;
     rv = scitoken_get_claim_string(m_read_token.get(), "wlcg.ver", &value,
                                    &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     ASSERT_TRUE(value != nullptr);
     std::unique_ptr<char, decltype(&free)> value_ptr(value, free);
     EXPECT_STREQ(value, "1.0");
@@ -416,12 +416,12 @@ TEST_F(SerializeTest, VerifyWLCGTest) {
 }
 
 TEST_F(SerializeTest, FailVerifyToken) {
-    char *err_msg;
+    char *err_msg = nullptr;
 
     std::unique_ptr<void, decltype(&scitoken_key_destroy)> mykey(
         scitoken_key_create("1", "ES256", ec_public_2, ec_private_2, &err_msg),
         scitoken_key_destroy);
-    ASSERT_TRUE(mykey.get() != nullptr);
+    ASSERT_TRUE(mykey.get() != nullptr) << err_msg;
 
     std::unique_ptr<void, decltype(&scitoken_destroy)> mytoken(
         scitoken_create(mykey.get()), scitoken_destroy);
@@ -429,11 +429,11 @@ TEST_F(SerializeTest, FailVerifyToken) {
 
     auto rv = scitoken_set_claim_string(
         mytoken.get(), "iss", "https://demo.scitokens.org/gtest", &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     char *value;
     rv = scitoken_serialize(mytoken.get(), &value, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     EXPECT_TRUE(value != nullptr);
     std::unique_ptr<char, decltype(&free)> value_ptr(value, free);
     EXPECT_TRUE(strlen(value) > 50);
@@ -451,20 +451,20 @@ TEST_F(SerializeTest, VerifyATJWTTest) {
     char *token_value = nullptr;
     scitoken_set_serialize_profile(m_token.get(), SciTokenProfile::AT_JWT);
     auto rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     std::unique_ptr<char, decltype(&free)> token_value_ptr(token_value, free);
 
     // Accepts any profile.
     rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr,
                                  &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     // Accepts only an at+jwt token, should work with at+jwt token
     scitoken_set_deserialize_profile(m_read_token.get(),
                                      SciTokenProfile::AT_JWT);
     rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr,
                                  &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     // Accepts only SciToken 2.0; should fail
     scitoken_set_deserialize_profile(m_read_token.get(),
@@ -482,13 +482,13 @@ TEST_F(SerializeTest, FailVerifyATJWTTest) {
     char *token_value = nullptr;
     scitoken_set_serialize_profile(m_token.get(), SciTokenProfile::COMPAT);
     auto rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     std::unique_ptr<char, decltype(&free)> token_value_ptr(token_value, free);
 
     // Accepts any profile.
     rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr,
                                  &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     // Accepts only an at+jwt token, should fail with COMPAT token
     scitoken_set_deserialize_profile(m_read_token.get(),
@@ -506,11 +506,11 @@ TEST_F(SerializeTest, EnforcerTest) {
 
     auto rv = scitoken_set_claim_string(
         m_token.get(), "aud", "https://demo.scitokens.org/", &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     auto enforcer = enforcer_create("https://demo.scitokens.org/gtest",
                                     &m_audiences_array[0], &err_msg);
-    ASSERT_TRUE(enforcer != nullptr);
+    ASSERT_TRUE(enforcer != nullptr) << err_msg;
 
     Acl acl;
     acl.authz = "read";
@@ -518,20 +518,20 @@ TEST_F(SerializeTest, EnforcerTest) {
 
     rv = scitoken_set_claim_string(m_token.get(), "scope", "read:/blah",
                                    &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     rv = scitoken_set_claim_string(m_token.get(), "ver", "scitoken:2.0",
                                    &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     char *token_value = nullptr;
     rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     std::unique_ptr<char, decltype(&free)> token_value_ptr(token_value, free);
 
     rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr,
                                  &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     rv = enforcer_test(enforcer, m_read_token.get(), &acl, &err_msg);
     ASSERT_STREQ(
@@ -545,30 +545,30 @@ TEST_F(SerializeTest, EnforcerScopeTest) {
 
     auto rv = scitoken_set_claim_string(
         m_token.get(), "aud", "https://demo.scitokens.org/", &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     auto enforcer = enforcer_create("https://demo.scitokens.org/gtest",
                                     &m_audiences_array[0], &err_msg);
-    ASSERT_TRUE(enforcer != nullptr);
+    ASSERT_TRUE(enforcer != nullptr) << err_msg;
 
     scitoken_set_serialize_profile(m_token.get(), SciTokenProfile::WLCG_1_0);
 
     rv = scitoken_set_claim_string(
         m_token.get(), "scope",
         "storage.modify:/ storage.read:/ openid offline_access", &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     char *token_value = nullptr;
     rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr,
                                  &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     Acl *acls;
     enforcer_generate_acls(enforcer, m_read_token.get(), &acls, &err_msg);
-    ASSERT_TRUE(acls != nullptr);
+    ASSERT_TRUE(acls != nullptr) << err_msg;
     int idx = 0;
     bool found_read = false;
     bool found_write = false;
@@ -596,7 +596,7 @@ TEST_F(SerializeTest, DeserializeAsyncTest) {
     char *token_value = nullptr;
     scitoken_set_serialize_profile(m_token.get(), SciTokenProfile::COMPAT);
     auto rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     std::unique_ptr<char, decltype(&free)> token_value_ptr(token_value, free);
 
     SciToken scitoken;
@@ -620,7 +620,7 @@ TEST_F(SerializeTest, FailDeserializeAsyncTest) {
     std::unique_ptr<void, decltype(&scitoken_key_destroy)> mykey(
         scitoken_key_create("1", "ES256", ec_public_2, ec_private_2, &err_msg),
         scitoken_key_destroy);
-    ASSERT_TRUE(mykey.get() != nullptr);
+    ASSERT_TRUE(mykey.get() != nullptr) << err_msg;
 
     std::unique_ptr<void, decltype(&scitoken_destroy)> mytoken(
         scitoken_create(mykey.get()), scitoken_destroy);
@@ -628,11 +628,11 @@ TEST_F(SerializeTest, FailDeserializeAsyncTest) {
 
     auto rv = scitoken_set_claim_string(
         mytoken.get(), "iss", "https://demo.scitokens.org/gtest", &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     char *value;
     rv = scitoken_serialize(mytoken.get(), &value, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     EXPECT_TRUE(value != nullptr);
     std::unique_ptr<char, decltype(&free)> value_ptr(value, free);
     EXPECT_TRUE(strlen(value) > 50);
@@ -657,34 +657,32 @@ TEST_F(SerializeTest, FailDeserializeAsyncTest) {
 
 TEST_F(SerializeTest, ExplicitTime) {
     time_t now = time(NULL);
-    char *err_msg;
+    char *err_msg = nullptr;
 
     scitoken_set_serialize_profile(m_token.get(), SciTokenProfile::WLCG_1_0);
     auto rv = scitoken_set_claim_string(m_token.get(), "scope",
                                         "storage.read:/", &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     char *token_value = nullptr;
     rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr,
                                  &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     auto enforcer = enforcer_create("https://demo.scitokens.org/gtest",
                                     &m_audiences_array[0], &err_msg);
-    ASSERT_TRUE(enforcer != nullptr);
+    ASSERT_TRUE(enforcer != nullptr) << err_msg;
     Acl *acls;
     rv = enforcer_generate_acls(enforcer, m_read_token.get(), &acls, &err_msg);
-    if (rv) {
-        printf("Failure when generating ACLs: %s\n", err_msg);
-    }
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     ASSERT_TRUE(acls != nullptr);
 
     enforcer_set_time(enforcer, time(NULL), &err_msg);
     rv = enforcer_generate_acls(enforcer, m_read_token.get(), &acls, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     enforcer_set_time(enforcer, time(NULL) + 100, &err_msg);
     rv = enforcer_generate_acls(enforcer, m_read_token.get(), &acls, &err_msg);
@@ -700,22 +698,22 @@ TEST_F(SerializeTest, ExplicitTime) {
 class SerializeNoKidTest : public ::testing::Test {
   protected:
     void SetUp() override {
-        char *err_msg;
+        char *err_msg = nullptr;
         m_key = KeyPtr(scitoken_key_create("none", "ES256", ec_public,
                                            ec_private, &err_msg),
                        scitoken_key_destroy);
-        ASSERT_TRUE(m_key.get() != nullptr);
+        ASSERT_TRUE(m_key.get() != nullptr) << err_msg;
 
         m_token = TokenPtr(scitoken_create(m_key.get()), scitoken_destroy);
         ASSERT_TRUE(m_token.get() != nullptr);
 
         auto rv = scitoken_set_claim_string(
             m_token.get(), "iss", "https://demo.scitokens.org/gtest", &err_msg);
-        ASSERT_TRUE(rv == 0);
+        ASSERT_TRUE(rv == 0) << err_msg;
 
         rv = scitoken_store_public_ec_key("https://demo.scitokens.org/gtest",
                                           "1", ec_public, &err_msg);
-        ASSERT_TRUE(rv == 0);
+        ASSERT_TRUE(rv == 0) << err_msg;
 
         scitoken_set_lifetime(m_token.get(), 60);
 
@@ -729,7 +727,7 @@ class SerializeNoKidTest : public ::testing::Test {
         groups[1] = group1;
         rv = scitoken_set_claim_string_list(m_token.get(), "groups", groups,
                                             &err_msg);
-        ASSERT_TRUE(rv == 0);
+        ASSERT_TRUE(rv == 0) << err_msg;
 
         m_read_token.reset(scitoken_create(nullptr));
         ASSERT_TRUE(m_read_token.get() != nullptr);
@@ -754,20 +752,20 @@ TEST_F(SerializeNoKidTest, VerifyATJWTTest) {
     char *token_value = nullptr;
     scitoken_set_serialize_profile(m_token.get(), SciTokenProfile::AT_JWT);
     auto rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
     std::unique_ptr<char, decltype(&free)> token_value_ptr(token_value, free);
 
     // Accepts any profile.
     rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr,
                                  &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     // Accepts only an at+jwt token, should work with at+jwt token
     scitoken_set_deserialize_profile(m_read_token.get(),
                                      SciTokenProfile::AT_JWT);
     rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr,
                                  &err_msg);
-    ASSERT_TRUE(rv == 0);
+    ASSERT_TRUE(rv == 0) << err_msg;
 
     // Accepts only SciToken 2.0; should fail
     scitoken_set_deserialize_profile(m_read_token.get(),


### PR DESCRIPTION
* Fix some compiler warnings
~~~
    .../src/scitokens_internal.h:673:25: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
      673 |         return std::move(result);
          |                ~~~~~~~~~^~~~~~~~
    .../src/scitokens_internal.h:673:25: note: remove 'std::move' call
    
    .../src/scitokens_internal.cpp:633:25: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
      633 |         return std::move(status);
          |                ~~~~~~~~~^~~~~~~~
    .../src/scitokens_internal.cpp:633:25: note: remove 'std::move' call
    
    .../src/scitokens_internal.cpp:747:13: warning: unused variable 'next_update' [-Wunused-variable]
      747 |     int64_t next_update, expires;
          |             ^~~~~~~~~~~
    
    .../src/scitokens_internal.cpp:747:26: warning: unused variable 'expires' [-Wunused-variable]
      747 |     int64_t next_update, expires;
          |                          ^~~~~~~
    
    .../test/main.cpp:442:12: warning: unused variable 'now' [-Wunused-variable]
      442 |     time_t now = time(NULL);
          |            ^~~
~~~
* Move key cache tests to the end to avoid random failures in other tests due to interference from changing the cache expiration settings in the key cache tests.

* Print err_msg in case of error

* Use resize() instead of reserve() to allocate vector elements
~~~
    [ RUN      ] SerializeTest.VerifyTest
    /usr/include/c++/13/bits/stl_vector.h:1125: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = unsigned char; _Alloc = std::allocator<unsigned char>; reference = unsigned char&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
~~~
