### PR TITLE
Disable CMake unity builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ set( CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}" )
 
 set( CMAKE_BUILD_TYPE RelWithDebInfo) # -g -O2
 
+set( CMAKE_UNITY_BUILD False)
+
 include(GNUInstallDirs)
 
 find_package( jwt-cpp REQUIRED )


### PR DESCRIPTION
Unity builds don't work in scitokens-cpp, but they wouldn't speed up builds much anyway, as there aren't a huge number of .cpp files per library. So, don't bother to fix the multiple inclusions problems that unity builds create, just disable the feature here.

Turning this off does allow scitokens-cpp to be built in a larger project that does turn on unity builds globally.