### PR TITLE
Fix compilation with GCC 15

### DIFF
--- a/vendor/jwt-cpp/include/jwt-cpp/base.h
+++ b/vendor/jwt-cpp/include/jwt-cpp/base.h
@@ -2,6 +2,7 @@
 #define JWT_CPP_BASE_H
 
 #include <array>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 


### PR DESCRIPTION
Include <cstdint> for fixed width integers used by base64 library.

See also: https://github.com/Thalhammer/jwt-cpp/pull/287
