### PR TITLE
Memory leaks in unit tests

### DIFF
--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -527,8 +527,6 @@ std::string rs256_from_coords(const std::string &e_str,
         throw UnsupportedKeyException("Failed to serialize RSA public key");
     }
 #endif
-    e_bignum.release();
-    n_bignum.release();
 
     char *mem_data;
     size_t mem_len = BIO_get_mem_data(pubkey_bio.get(), &mem_data);

--- a/src/verify.cpp
+++ b/src/verify.cpp
@@ -123,6 +123,7 @@ int main(int argc, char *const *argv) {
         std::cout << "Failed to deserialize a token: " << err_msg << std::endl;
         return 1;
     }
+    scitoken_destroy(scitoken);
     std::cout << "Token deserialization successful." << std::endl;
 
     return 0;


### PR DESCRIPTION
Turning on the address sanitizer reveals that the unit tests themselves have several memory leaks.  Let's fix those, so that we can get clean asan runs in CI.