### PR TITLE
Set CURLOPT_NOSIGNAL option in SimpleCurlGet to prevent signal interruptions

### DIFF
--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -80,6 +80,12 @@ SimpleCurlGet::GetStatus SimpleCurlGet::perform_start(const std::string &url) {
     if (rv != CURLE_OK) {
         throw CurlException("Failed to set CURLOPT_FOLLOWLOCATION.");
     }
+    // Disable signal handling to avoid issues in multi-threaded contexts.
+    rv = curl_easy_setopt(m_curl.get(), CURLOPT_NOSIGNAL, 1L);
+    if (rv != CURLE_OK) {
+        throw CurlException("Failed to set CURLOPT_NOSIGNAL.");
+    }
+    
 
     auto ca_file = configurer::Configuration::get_tls_ca_file();
     if (!ca_file.empty()) {

--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -85,7 +85,6 @@ SimpleCurlGet::GetStatus SimpleCurlGet::perform_start(const std::string &url) {
     if (rv != CURLE_OK) {
         throw CurlException("Failed to set CURLOPT_NOSIGNAL.");
     }
-    
 
     auto ca_file = configurer::Configuration::get_tls_ca_file();
     if (!ca_file.empty()) {


### PR DESCRIPTION
Fixes #148