### PR TITLE
Revert "Fix memory leak in rs256_from_coords"

### DIFF
--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -532,6 +532,8 @@ std::string rs256_from_coords(const std::string &e_str,
         throw UnsupportedKeyException("Failed to serialize RSA public key");
     }
 #endif
+    e_bignum.release();
+    n_bignum.release();
 
     char *mem_data;
     size_t mem_len = BIO_get_mem_data(pubkey_bio.get(), &mem_data);


### PR DESCRIPTION
This reverts commit d0bf032840df0fbf29a7779b9189774b0028c30e.

Found with git bisect.  Only occurs on el8.  Likely an change in OpenSSL behavior?