### PR TITLE
Fix segfault if the JSON parser cannot parse the JWKS

### DIFF
--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -734,12 +734,12 @@ std::unique_ptr<AsyncStatus> Validator::get_public_keys_from_web_continue(
         auto metadata = std::string(buffer, len);
         picojson::value json_obj;
         auto err = picojson::parse(json_obj, metadata);
-        status->m_cget.reset();
         if (!err.empty()) {
             throw JsonException("JSON parse failure when downloading from the "
                                 " public key URL " +
                                 status->m_cget->get_url() + ": " + err);
         }
+        status->m_cget.reset();
 
         auto now = std::time(NULL);
         // TODO: take expiration time from the cache-control header in the


### PR DESCRIPTION
Ensure m_cget is still valid when building the exception text with m_cget->get_url().

If the issuer published a JWKS that's not valid JSON, it triggers an exception. The unique_ptr is accessed to build the exception text. Move the reset() to after the exception to avoid a segfault.
```
scitokens::internal::SimpleCurlGet::get_url[abi:cxx11]() const (this=0x0) at /tmp/mnt/src/scitokens_internal.cpp:108
108         if (!m_curl) {
(gdb) bt
#0  scitokens::internal::SimpleCurlGet::get_url[abi:cxx11]() const (this=0x0) at /tmp/mnt/src/scitokens_internal.cpp:108
#1  0x00007f4f4997b293 in scitokens::Validator::get_public_keys_from_web_continue (status=...) at /tmp/mnt/src/scitokens_internal.cpp:741
#2  0x00007f4f4999a267 in scitokens::Validator::refresh_jwks (issuer=...) at /usr/local/include/c++/14.2.0/bits/unique_ptr.h:191
#3  0x00007f4f4997e90f in keycache_refresh_jwks (issuer=0x4f4898 "https://t2.unl.edu/jthiltge/issuer/invalid", err_msg=0x7ffe0145bec0) at /usr/local/include/c++/14.2.0/bits/basic_string.tcc:242
```