### PR TITLE
Check if libatomic is needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 include(GNUInstallDirs)
 
 find_package( jwt-cpp REQUIRED )
+find_package( Atomic REQUIRED )
 find_package( CURL REQUIRED )
 find_package( UUID REQUIRED )
 
@@ -51,7 +52,7 @@ target_include_directories(SciTokens PUBLIC ${JWT_CPP_INCLUDES} "${PROJECT_SOURC
 # Find threading library
 find_package(Threads REQUIRED)
 
-target_link_libraries(SciTokens PUBLIC ${OPENSSL_LIBRARIES} ${LIBCRYPTO_LIBRARIES} ${CURL_LIBRARIES} ${SQLITE_LIBRARIES} ${UUID_LIBRARIES} Threads::Threads)
+target_link_libraries(SciTokens PUBLIC ${OPENSSL_LIBRARIES} ${LIBCRYPTO_LIBRARIES} ${CURL_LIBRARIES} ${SQLITE_LIBRARIES} ${UUID_LIBRARIES} Threads::Threads std::atomic)
 if (UNIX)
 # pkg_check_modules fails to return an absolute path on RHEL7.  Set the
 # link directories accordingly.

--- a/cmake/FindAtomic.cmake
+++ b/cmake/FindAtomic.cmake
@@ -1,0 +1,42 @@
+include(CheckCXXSourceCompiles)
+
+function( check_working_cxx_atomics varname )
+  CHECK_CXX_SOURCE_COMPILES("
+    #include <cstdlib>
+    #include <atomic>
+    #include <cstdint>
+
+    int main() {
+      std::atomic<uint8_t> a1;
+      std::atomic<uint16_t> a2;
+      std::atomic<uint32_t> a3;
+      std::atomic<uint64_t> a4;
+      return a1++ + a2++ + a3++ + a4++;
+    }" ${varname}
+  )
+endfunction( check_working_cxx_atomics varname )
+
+set( _found FALSE )
+check_working_cxx_atomics( CXX_ATOMIC_NO_LINK_NEEDED )
+if( CXX_ATOMIC_NO_LINK_NEEDED )
+  set( _found TRUE )
+else()
+  set( OLD_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} )
+  list( APPEND CMAKE_REQUIRED_LIBRARIES "atomic" )
+  check_working_cxx_atomics( HAVE_CXX_ATOMICS_WITH_LIB )
+  set( CMAKE_REQUIRED_LIBRARIES ${OLD_CMAKE_REQUIRED_LIBRARIES} )
+  if( HAVE_CXX_ATOMICS_WITH_LIB )
+    set( _found TRUE )
+  endif()
+endif()
+
+add_library( std::atomic INTERFACE IMPORTED GLOBAL )
+
+if( HAVE_CXX_ATOMICS_WITH_LIB )
+  set_property( TARGET std::atomic APPEND PROPERTY INTERFACE_LINK_LIBRARIES atomic )
+endif()
+
+set( Atomic_FOUND ${_found} CACHE BOOL "TRUE if we can run a program using std::atomic" FORCE )
+if( Atomic_FIND_REQUIRED AND NOT Atomic_FOUND )
+    message( FATAL_ERROR "Cannot run simple program using std::atomic" )
+endif()


### PR DESCRIPTION
/usr/bin/powerpc-linux-gnu-ld.bfd: CMakeFiles/scitokens-integration-test.dir/integration_test.cpp.o: undefined reference to symbol '__atomic_load_8@@LIBATOMIC_1.0'
/usr/bin/powerpc-linux-gnu-ld.bfd: /usr/lib/powerpc-linux-gnu/libatomic.so.1: error adding symbols: DSO missing from command line