### PR TITLE
scitokens_internal: scitokens-style translation for AT_JWT

### DIFF
--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -1432,12 +1432,13 @@ bool scitokens::Enforcer::scope_validator(const jwt::claim &claim,
             return false;
         }
 
-        // If we are in compatibility mode and this is a WLCG token, then
-        // translate the authorization names to utilize the SciToken-style
+        // If we are in compatibility mode and this is a WLCG or AT_JWT token,
+        // then translate the authorization names to utilize the SciToken-style
         // names.
         std::string alt_authz;
         if (me->m_validate_profile == SciToken::Profile::COMPAT &&
-            me->m_validator.get_profile() == SciToken::Profile::WLCG_1_0) {
+            (me->m_validator.get_profile() == SciToken::Profile::WLCG_1_0 ||
+             me->m_validator.get_profile() == SciToken::Profile::AT_JWT)) {
             if (authz == "storage.read") {
                 authz = "read";
             } else if (authz == "storage.create") {


### PR DESCRIPTION
`AT+JWT` tokens can be used in a similar fashion to WLCG tokens. Other tooling (e.g. `xrootd`) relies on the translation of `authz` to the SciToken-style names, so extend this translation to the generic `at+jwt` token profile in `compat` mode.

This complements #53 as the Unity IAM has now learned to handle custom scopes so it can produce tokens carrying the same information a WLCG token would carry (albeit with the generic `at+jwt` profile). 