### PR TITLE
Fix scitoken_status_free: missing C-linkage symbol and status type confusion

### DIFF
--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -483,6 +483,12 @@ int scitoken_deserialize_start(const char *value, SciToken *token,
         }
         return -1;
     }
+    if (status_out == nullptr) {
+        if (err_msg) {
+            *err_msg = strdup("Output status not provided");
+        }
+        return -1;
+    }
 
     scitokens::SciTokenKey key;
     scitokens::SciToken *real_token = new scitokens::SciToken(key);
@@ -839,7 +845,13 @@ int enforcer_generate_acls_start(const Enforcer enf, const SciToken scitoken,
         *status_out = nullptr;
         return 0;
     }
-    *status_out = status.release();
+    // Wrap in a SciTokenAsyncStatus so all SciTokenStatus handles exposed
+    // through the C API share one concrete type; scitoken_status_free and
+    // the scitoken_status_get_* accessors rely on this.
+    std::unique_ptr<scitokens::SciTokenAsyncStatus> wrapper(
+        new scitokens::SciTokenAsyncStatus());
+    wrapper->m_status = std::move(status);
+    *status_out = wrapper.release();
     return 0;
 }
 
@@ -860,11 +872,11 @@ int enforcer_generate_acls_continue(const Enforcer enf, SciTokenStatus *status,
     }
 
     scitokens::Enforcer::AclsList acls_list;
-    std::unique_ptr<scitokens::AsyncStatus> status_internal(
-        reinterpret_cast<scitokens::AsyncStatus *>(*status));
+    std::unique_ptr<scitokens::SciTokenAsyncStatus> wrapper(
+        reinterpret_cast<scitokens::SciTokenAsyncStatus *>(*status));
     try {
-        status_internal = real_enf->generate_acls_continue(
-            std::move(status_internal), acls_list);
+        wrapper->m_status = real_enf->generate_acls_continue(
+            std::move(wrapper->m_status), acls_list);
     } catch (std::exception &exc) {
         *status = nullptr;
         if (err_msg) {
@@ -872,7 +884,7 @@ int enforcer_generate_acls_continue(const Enforcer enf, SciTokenStatus *status,
         }
         return -1;
     }
-    if (status_internal->m_done) {
+    if (wrapper->m_status->m_done) {
         auto result_acls = convert_acls(acls_list, err_msg);
         if (!result_acls) {
             return -1;
@@ -881,7 +893,7 @@ int enforcer_generate_acls_continue(const Enforcer enf, SciTokenStatus *status,
         *status = nullptr;
         return 0;
     }
-    *status = status_internal.release();
+    *status = wrapper.release();
     return 0;
 }
 
@@ -921,9 +933,17 @@ int enforcer_test(const Enforcer enf, const SciToken scitoken, const Acl *acl,
     return 0;
 }
 
-void scitoken_status_free(SciTokenStatus status) {
-    std::unique_ptr<scitokens::AsyncStatus> status_real(
-        reinterpret_cast<scitokens::AsyncStatus *>(status));
+void scitoken_status_free(SciTokenStatus *status) {
+    if (status == nullptr || *status == nullptr) {
+        return;
+    }
+    // All SciTokenStatus handles returned by the public API are
+    // SciTokenAsyncStatus objects (enforcer statuses are wrapped in
+    // enforcer_generate_acls_start/continue), so this is the correct
+    // concrete type to destroy.
+    std::unique_ptr<scitokens::SciTokenAsyncStatus> status_real(
+        reinterpret_cast<scitokens::SciTokenAsyncStatus *>(*status));
+    *status = nullptr;
 }
 
 int scitoken_status_get_timeout_val(const SciTokenStatus *status,

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -683,6 +683,35 @@ TEST_F(SerializeTest, DeserializeAsyncTest) {
     scitoken_destroy(scitoken);
 }
 
+TEST_F(SerializeTest, StatusFreeTest) {
+    char *err_msg = nullptr;
+
+    char *token_value = nullptr;
+    auto rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+    std::unique_ptr<char, decltype(&free)> token_value_ptr(token_value, free);
+
+    SciToken scitoken;
+    SciTokenStatus status;
+    rv = scitoken_deserialize_start(token_value, &scitoken, nullptr, &status,
+                                    &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+
+    // Abandon the operation mid-flight: freeing the status must not crash
+    // and must null the handle.  (This also verifies the C-linkage symbol
+    // for scitoken_status_free resolves; it was previously only emitted
+    // with a mismatched C++ signature.)
+    scitoken_status_free(&status);
+    EXPECT_EQ(status, nullptr);
+
+    // Freeing a null status handle is a no-op.
+    scitoken_status_free(&status);
+    EXPECT_EQ(status, nullptr);
+    scitoken_status_free(nullptr);
+
+    scitoken_destroy(scitoken);
+}
+
 TEST_F(SerializeTest, FailDeserializeAsyncTest) {
     char *err_msg = nullptr;
 


### PR DESCRIPTION
## Problem

Three related bugs in the async-status C API:

1. **The C symbol doesn't exist.** `scitokens.h` declares `void scitoken_status_free(SciTokenStatus *status)` inside `extern "C"`, but `scitokens.cpp` defines `scitoken_status_free(SciTokenStatus status)` — a different parameter type. C++ treats that as a *separate overload with C++ linkage*, so the library only exports the mangled `_Z20scitoken_status_freePv`. Any C consumer using the public header gets an undefined symbol at link time. On Linux it's worse: the mangled name doesn't match the `scitoken*` glob in `configs/export-symbols`, so the function isn't exported in any form. (Verified with `nm` before/after.)

2. **Type confusion on free.** The implementation deletes the handle as `scitokens::AsyncStatus*`, but statuses returned by `scitoken_deserialize_start` are `SciTokenAsyncStatus*` — an unrelated type holding two `unique_ptr`s. Deleting through the wrong type runs `~AsyncStatus` over unrelated memory (its `std::unique_lock` members get destroyed reading garbage — potential unlock of a wild mutex pointer) and leaks the real members.

3. **Accessor type confusion for enforcer statuses.** `scitoken_status_get_timeout_val` / `_get_read_fd_set` / etc. cast the handle to `SciTokenAsyncStatus*`, but `enforcer_generate_acls_start` returned a raw `AsyncStatus*` — so using the select()-loop accessors with the enforcer async API read garbage.

## Fix

- Match the declared signature; also null the caller's handle and make null input a no-op.
- Wrap enforcer async statuses in `SciTokenAsyncStatus` (start) and unwrap on continue, so **every** `SciTokenStatus` handle exposed through the C API is the same concrete type. This simultaneously fixes the free path and the `scitoken_status_get_*` accessors for enforcer statuses.
- Reject a null `status_out` in `scitoken_deserialize_start` instead of dereferencing it.

## Testing

- New regression test frees an async status mid-flight (and a null handle); the test calling the function at all verifies the C-linkage symbol resolves — it did not before this change.
- `nm libSciTokens.dylib` now shows `T _scitoken_status_free` (unmangled).
- `ctest` unit, env_config, and monitoring suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)