### PR TITLE
Fix crash when the configured cache home contains no path components

### DIFF
--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -1499,6 +1499,13 @@ configurer::Configuration::set_cache_home(const std::string dir_path) {
 
     std::vector<std::string> path_components =
         path_split(dir_path); // cleans any extraneous /'s
+    if (path_components.empty()) {
+        // A path of only slashes (e.g. "/") has no components and would
+        // otherwise be silently stored as an empty cache home.
+        return std::make_pair(false,
+                              "The provided cache home path does not contain "
+                              "any path components");
+    }
     std::string cleaned_dir_path;
     for (const auto &component :
          path_components) { // add the / back to the path components
@@ -1593,8 +1600,5 @@ configurer::Configuration::path_split(std::string path) {
         }
     }
 
-    if (path_components[0] == "") {
-        path_components.erase(path_components.begin());
-    }
     return path_components;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1092,8 +1092,8 @@ TEST_F(KeycacheTest, SetCacheHomeAllSlashesTest) {
     // caused an out-of-bounds access on an empty vector).
     for (const char *path : {"/", "//", "///"}) {
         char *err_msg = nullptr;
-        auto rv = scitoken_config_set_str("keycache.cache_home", path,
-                                          &err_msg);
+        auto rv =
+            scitoken_config_set_str("keycache.cache_home", path, &err_msg);
         EXPECT_FALSE(rv == 0) << "path: " << path;
         if (err_msg) {
             free(err_msg);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1086,6 +1086,21 @@ TEST_F(KeycacheTest, GetKeycacheLocation) {
     }
 }
 
+TEST_F(KeycacheTest, SetCacheHomeAllSlashesTest) {
+    // A cache home consisting only of slashes has no path components;
+    // it must be rejected with an error, not crash (previously this
+    // caused an out-of-bounds access on an empty vector).
+    for (const char *path : {"/", "//", "///"}) {
+        char *err_msg = nullptr;
+        auto rv = scitoken_config_set_str("keycache.cache_home", path,
+                                          &err_msg);
+        EXPECT_FALSE(rv == 0) << "path: " << path;
+        if (err_msg) {
+            free(err_msg);
+        }
+    }
+}
+
 TEST_F(KeycacheTest, InvalidConfigKeyTest) {
     char *err_msg = nullptr;
     int new_update_interval = 400;


### PR DESCRIPTION
## Problem

`Configuration::path_split()` accessed `path_components[0]` without checking whether the vector is empty. Any cache-home value consisting only of slashes (`/`, `//`, …) produces an empty vector, so the access is out of bounds — a reproducible SIGSEGV:

```c
scitoken_config_set_str("keycache.cache_home", "/", &err);  // segfault
```

Because `load_config_from_environment()` runs from a `__attribute__((constructor))`, setting `SCITOKEN_CONFIG_KEYCACHE_CACHE_HOME=/` in the environment **crashes any application that links the library, at load time**.

The `path_components[0] == ""` check was also dead code: empty components are already filtered inside the split loop, so the first element can never be empty.

## Fix

- Remove the dead (and crashing) check from `path_split()`.
- Reject component-less cache-home paths in `set_cache_home()` with a proper error message instead of silently storing an empty cache home.

## Testing

- New regression test `KeycacheTest.SetCacheHomeAllSlashesTest` covers `/`, `//`, `///` (crashed before, clean error after).
- Standalone repro that segfaulted before this change now returns `rv=-1` with the error message.
- `ctest` unit, env_config, and monitoring suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)