### PR TITLE
Fix use-after-free race between monitoring reset() and in-flight validations

### DIFF
--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -376,6 +376,50 @@ struct IssuerStats {
                    failed_key_lookup_time_ns.load(std::memory_order_relaxed)) /
                1e9;
     }
+
+    // Zero all counters in place.  Used by MonitoringStats::reset(), which
+    // must never destroy IssuerStats objects because in-flight validations
+    // hold references to them (see get_issuer_stats).
+    void reset_counters() {
+        successful_validations.store(0, std::memory_order_relaxed);
+        unsuccessful_validations.store(0, std::memory_order_relaxed);
+        expired_tokens.store(0, std::memory_order_relaxed);
+        sync_validations_started.store(0, std::memory_order_relaxed);
+        async_validations_started.store(0, std::memory_order_relaxed);
+        sync_total_time_ns.store(0, std::memory_order_relaxed);
+        async_total_time_ns.store(0, std::memory_order_relaxed);
+        successful_key_lookups.store(0, std::memory_order_relaxed);
+        failed_key_lookups.store(0, std::memory_order_relaxed);
+        failed_key_lookup_time_ns.store(0, std::memory_order_relaxed);
+        expired_keys.store(0, std::memory_order_relaxed);
+        failed_refreshes.store(0, std::memory_order_relaxed);
+        stale_key_uses.store(0, std::memory_order_relaxed);
+        background_successful_refreshes.store(0, std::memory_order_relaxed);
+        background_failed_refreshes.store(0, std::memory_order_relaxed);
+        negative_cache_hits.store(0, std::memory_order_relaxed);
+    }
+
+    // True if any counter has been incremented since the last reset.
+    // Entries with no activity are omitted from the JSON report.
+    bool has_activity() const {
+        return successful_validations.load(std::memory_order_relaxed) ||
+               unsuccessful_validations.load(std::memory_order_relaxed) ||
+               expired_tokens.load(std::memory_order_relaxed) ||
+               sync_validations_started.load(std::memory_order_relaxed) ||
+               async_validations_started.load(std::memory_order_relaxed) ||
+               sync_total_time_ns.load(std::memory_order_relaxed) ||
+               async_total_time_ns.load(std::memory_order_relaxed) ||
+               successful_key_lookups.load(std::memory_order_relaxed) ||
+               failed_key_lookups.load(std::memory_order_relaxed) ||
+               failed_key_lookup_time_ns.load(std::memory_order_relaxed) ||
+               expired_keys.load(std::memory_order_relaxed) ||
+               failed_refreshes.load(std::memory_order_relaxed) ||
+               stale_key_uses.load(std::memory_order_relaxed) ||
+               background_successful_refreshes.load(
+                   std::memory_order_relaxed) ||
+               background_failed_refreshes.load(std::memory_order_relaxed) ||
+               negative_cache_hits.load(std::memory_order_relaxed);
+    }
 };
 
 /**

--- a/src/scitokens_monitoring.cpp
+++ b/src/scitokens_monitoring.cpp
@@ -83,6 +83,13 @@ std::string MonitoringStats::get_json() const {
         const std::string &issuer = entry.first;
         const IssuerStats &stats = entry.second;
 
+        // Entries survive reset() with zeroed counters (in-flight
+        // validations may hold references to them); don't report them
+        // until they see activity again.
+        if (!stats.has_activity()) {
+            continue;
+        }
+
         picojson::object issuer_obj;
         issuer_obj["successful_validations"] =
             picojson::value(static_cast<int64_t>(
@@ -166,7 +173,17 @@ std::string MonitoringStats::get_json() const {
 
 void MonitoringStats::reset() {
     std::lock_guard<std::mutex> lock(m_mutex);
-    m_issuer_stats.clear();
+    // Never erase IssuerStats entries: get_issuer_stats() hands out
+    // references that in-flight validations hold across the whole
+    // verification (its contract promises they live as long as the
+    // singleton).  Erasing them here would be a use-after-free for any
+    // concurrent verify(); zero the counters in place instead.  Entries
+    // with all-zero counters are omitted from get_json().
+    for (auto &entry : m_issuer_stats) {
+        entry.second.reset_counters();
+    }
+    // The failed-issuer map stores plain values that are only accessed
+    // under m_mutex, so clearing it is safe.
     m_failed_issuer_lookups.clear();
 }
 


### PR DESCRIPTION
## Problem

`MonitoringStats::get_issuer_stats()` documents that the returned reference *"remains valid for the lifetime of the singleton"*, and `Validator::verify()` relies on that — it holds an `IssuerStats*` across the entire validation loop, updating duration counters after every `select()` wakeup.

`MonitoringStats::reset()` broke that contract by calling `m_issuer_stats.clear()`, destroying all entries. Any thread calling `scitoken_reset_monitoring_stats()` while another thread has a verification in flight leaves the verifying thread incrementing **freed** atomics — a use-after-free data race.

## Fix

- `reset()` zeroes every entry's counters in place (new `IssuerStats::reset_counters()`) instead of erasing entries, preserving reference stability.
- `get_json()` skips entries whose counters are all zero (new `IssuerStats::has_activity()`), so a reset still yields an empty report and the existing monitoring tests' expectations (`getIssuerCount() == 0` after reset) keep passing.
- `m_failed_issuer_lookups` holds plain values only ever accessed under the mutex, so clearing it remains safe.

## Testing

- `ctest` unit, env_config, and monitoring suites pass (the monitoring suite includes reset + JSON assertions that exercise both changed paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)