### PR TITLE
Bound the per-issuer monitoring map against unbounded growth

### DIFF
--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -443,9 +443,22 @@ class MonitoringStats {
      * Get a reference to an issuer's statistics, creating the entry if needed.
      * The returned reference remains valid for the lifetime of the singleton.
      * All IssuerStats fields are atomic, so concurrent access is safe.
+     *
+     * Issuer strings come from tokens that have not been validated yet, so
+     * an attacker can supply arbitrarily many distinct values.  Once
+     * MAX_TRACKED_ISSUERS distinct issuers are tracked, further issuers
+     * share a single aggregate overflow bucket (reported as "<other>" in
+     * the JSON output) rather than growing the map without bound.
      */
     IssuerStats &get_issuer_stats(const std::string &issuer) {
         std::lock_guard<std::mutex> lock(m_mutex);
+        auto iter = m_issuer_stats.find(issuer);
+        if (iter != m_issuer_stats.end()) {
+            return iter->second;
+        }
+        if (m_issuer_stats.size() >= MAX_TRACKED_ISSUERS) {
+            return m_overflow_stats;
+        }
         return m_issuer_stats[issuer];
     }
 
@@ -484,9 +497,13 @@ class MonitoringStats {
 
     // Limit the number of failed issuer entries to prevent DDoS
     static constexpr size_t MAX_FAILED_ISSUERS = 100;
+    // Limit the number of tracked issuers; entries beyond this share the
+    // overflow bucket (issuer names are attacker-controlled token input)
+    static constexpr size_t MAX_TRACKED_ISSUERS = 1000;
 
     mutable std::mutex m_mutex;
     std::unordered_map<std::string, IssuerStats> m_issuer_stats;
+    IssuerStats m_overflow_stats;
     std::unordered_map<std::string, FailedIssuerStats> m_failed_issuer_lookups;
 
     // Atomic timestamp for last monitoring file write (seconds since epoch)
@@ -494,6 +511,7 @@ class MonitoringStats {
     std::atomic<int64_t> m_last_file_write_time{0};
 
     std::string sanitize_issuer_for_json(const std::string &issuer) const;
+    picojson::object serialize_issuer_stats(const IssuerStats &stats) const;
     void prune_failed_issuers();
     void write_monitoring_file_impl() noexcept;
 };

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -376,6 +376,50 @@ struct IssuerStats {
                    failed_key_lookup_time_ns.load(std::memory_order_relaxed)) /
                1e9;
     }
+
+    // Zero all counters in place.  Used by MonitoringStats::reset(), which
+    // must never destroy IssuerStats objects because in-flight validations
+    // hold references to them (see get_issuer_stats).
+    void reset_counters() {
+        successful_validations.store(0, std::memory_order_relaxed);
+        unsuccessful_validations.store(0, std::memory_order_relaxed);
+        expired_tokens.store(0, std::memory_order_relaxed);
+        sync_validations_started.store(0, std::memory_order_relaxed);
+        async_validations_started.store(0, std::memory_order_relaxed);
+        sync_total_time_ns.store(0, std::memory_order_relaxed);
+        async_total_time_ns.store(0, std::memory_order_relaxed);
+        successful_key_lookups.store(0, std::memory_order_relaxed);
+        failed_key_lookups.store(0, std::memory_order_relaxed);
+        failed_key_lookup_time_ns.store(0, std::memory_order_relaxed);
+        expired_keys.store(0, std::memory_order_relaxed);
+        failed_refreshes.store(0, std::memory_order_relaxed);
+        stale_key_uses.store(0, std::memory_order_relaxed);
+        background_successful_refreshes.store(0, std::memory_order_relaxed);
+        background_failed_refreshes.store(0, std::memory_order_relaxed);
+        negative_cache_hits.store(0, std::memory_order_relaxed);
+    }
+
+    // True if any counter has been incremented since the last reset.
+    // Entries with no activity are omitted from the JSON report.
+    bool has_activity() const {
+        return successful_validations.load(std::memory_order_relaxed) ||
+               unsuccessful_validations.load(std::memory_order_relaxed) ||
+               expired_tokens.load(std::memory_order_relaxed) ||
+               sync_validations_started.load(std::memory_order_relaxed) ||
+               async_validations_started.load(std::memory_order_relaxed) ||
+               sync_total_time_ns.load(std::memory_order_relaxed) ||
+               async_total_time_ns.load(std::memory_order_relaxed) ||
+               successful_key_lookups.load(std::memory_order_relaxed) ||
+               failed_key_lookups.load(std::memory_order_relaxed) ||
+               failed_key_lookup_time_ns.load(std::memory_order_relaxed) ||
+               expired_keys.load(std::memory_order_relaxed) ||
+               failed_refreshes.load(std::memory_order_relaxed) ||
+               stale_key_uses.load(std::memory_order_relaxed) ||
+               background_successful_refreshes.load(
+                   std::memory_order_relaxed) ||
+               background_failed_refreshes.load(std::memory_order_relaxed) ||
+               negative_cache_hits.load(std::memory_order_relaxed);
+    }
 };
 
 /**

--- a/src/scitokens_monitoring.cpp
+++ b/src/scitokens_monitoring.cpp
@@ -72,6 +72,63 @@ void MonitoringStats::prune_failed_issuers() {
     }
 }
 
+picojson::object
+MonitoringStats::serialize_issuer_stats(const IssuerStats &stats) const {
+    picojson::object issuer_obj;
+    issuer_obj["successful_validations"] = picojson::value(static_cast<int64_t>(
+        stats.successful_validations.load(std::memory_order_relaxed)));
+    issuer_obj["unsuccessful_validations"] =
+        picojson::value(static_cast<int64_t>(
+            stats.unsuccessful_validations.load(std::memory_order_relaxed)));
+    issuer_obj["expired_tokens"] = picojson::value(static_cast<int64_t>(
+        stats.expired_tokens.load(std::memory_order_relaxed)));
+
+    // Validation started counters
+    issuer_obj["sync_validations_started"] =
+        picojson::value(static_cast<int64_t>(
+            stats.sync_validations_started.load(std::memory_order_relaxed)));
+    issuer_obj["async_validations_started"] =
+        picojson::value(static_cast<int64_t>(
+            stats.async_validations_started.load(std::memory_order_relaxed)));
+
+    // Duration tracking
+    issuer_obj["sync_total_time_s"] = picojson::value(stats.get_sync_time_s());
+    issuer_obj["async_total_time_s"] =
+        picojson::value(stats.get_async_time_s());
+    issuer_obj["total_validation_time_s"] =
+        picojson::value(stats.get_total_time_s());
+
+    // Web lookup statistics
+    issuer_obj["successful_key_lookups"] = picojson::value(static_cast<int64_t>(
+        stats.successful_key_lookups.load(std::memory_order_relaxed)));
+    issuer_obj["failed_key_lookups"] = picojson::value(static_cast<int64_t>(
+        stats.failed_key_lookups.load(std::memory_order_relaxed)));
+    issuer_obj["failed_key_lookup_time_s"] =
+        picojson::value(stats.get_failed_key_lookup_time_s());
+
+    // Key refresh statistics
+    issuer_obj["expired_keys"] = picojson::value(static_cast<int64_t>(
+        stats.expired_keys.load(std::memory_order_relaxed)));
+    issuer_obj["failed_refreshes"] = picojson::value(static_cast<int64_t>(
+        stats.failed_refreshes.load(std::memory_order_relaxed)));
+    issuer_obj["stale_key_uses"] = picojson::value(static_cast<int64_t>(
+        stats.stale_key_uses.load(std::memory_order_relaxed)));
+
+    // Background refresh statistics
+    issuer_obj["background_successful_refreshes"] = picojson::value(
+        static_cast<int64_t>(stats.background_successful_refreshes.load(
+            std::memory_order_relaxed)));
+    issuer_obj["background_failed_refreshes"] =
+        picojson::value(static_cast<int64_t>(
+            stats.background_failed_refreshes.load(std::memory_order_relaxed)));
+
+    // Negative cache statistics
+    issuer_obj["negative_cache_hits"] = picojson::value(static_cast<int64_t>(
+        stats.negative_cache_hits.load(std::memory_order_relaxed)));
+
+    return issuer_obj;
+}
+
 std::string MonitoringStats::get_json() const {
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -80,74 +137,21 @@ std::string MonitoringStats::get_json() const {
 
     // Add per-issuer statistics
     for (const auto &entry : m_issuer_stats) {
-        const std::string &issuer = entry.first;
-        const IssuerStats &stats = entry.second;
-
         // Entries survive reset() with zeroed counters (in-flight
         // validations may hold references to them); don't report them
         // until they see activity again.
-        if (!stats.has_activity()) {
+        if (!entry.second.has_activity()) {
             continue;
         }
+        std::string sanitized_issuer = sanitize_issuer_for_json(entry.first);
+        issuers_obj[sanitized_issuer] =
+            picojson::value(serialize_issuer_stats(entry.second));
+    }
 
-        picojson::object issuer_obj;
-        issuer_obj["successful_validations"] =
-            picojson::value(static_cast<int64_t>(
-                stats.successful_validations.load(std::memory_order_relaxed)));
-        issuer_obj["unsuccessful_validations"] = picojson::value(
-            static_cast<int64_t>(stats.unsuccessful_validations.load(
-                std::memory_order_relaxed)));
-        issuer_obj["expired_tokens"] = picojson::value(static_cast<int64_t>(
-            stats.expired_tokens.load(std::memory_order_relaxed)));
-
-        // Validation started counters
-        issuer_obj["sync_validations_started"] = picojson::value(
-            static_cast<int64_t>(stats.sync_validations_started.load(
-                std::memory_order_relaxed)));
-        issuer_obj["async_validations_started"] = picojson::value(
-            static_cast<int64_t>(stats.async_validations_started.load(
-                std::memory_order_relaxed)));
-
-        // Duration tracking
-        issuer_obj["sync_total_time_s"] =
-            picojson::value(stats.get_sync_time_s());
-        issuer_obj["async_total_time_s"] =
-            picojson::value(stats.get_async_time_s());
-        issuer_obj["total_validation_time_s"] =
-            picojson::value(stats.get_total_time_s());
-
-        // Web lookup statistics
-        issuer_obj["successful_key_lookups"] =
-            picojson::value(static_cast<int64_t>(
-                stats.successful_key_lookups.load(std::memory_order_relaxed)));
-        issuer_obj["failed_key_lookups"] = picojson::value(static_cast<int64_t>(
-            stats.failed_key_lookups.load(std::memory_order_relaxed)));
-        issuer_obj["failed_key_lookup_time_s"] =
-            picojson::value(stats.get_failed_key_lookup_time_s());
-
-        // Key refresh statistics
-        issuer_obj["expired_keys"] = picojson::value(static_cast<int64_t>(
-            stats.expired_keys.load(std::memory_order_relaxed)));
-        issuer_obj["failed_refreshes"] = picojson::value(static_cast<int64_t>(
-            stats.failed_refreshes.load(std::memory_order_relaxed)));
-        issuer_obj["stale_key_uses"] = picojson::value(static_cast<int64_t>(
-            stats.stale_key_uses.load(std::memory_order_relaxed)));
-
-        // Background refresh statistics
-        issuer_obj["background_successful_refreshes"] = picojson::value(
-            static_cast<int64_t>(stats.background_successful_refreshes.load(
-                std::memory_order_relaxed)));
-        issuer_obj["background_failed_refreshes"] = picojson::value(
-            static_cast<int64_t>(stats.background_failed_refreshes.load(
-                std::memory_order_relaxed)));
-
-        // Negative cache statistics
-        issuer_obj["negative_cache_hits"] =
-            picojson::value(static_cast<int64_t>(
-                stats.negative_cache_hits.load(std::memory_order_relaxed)));
-
-        std::string sanitized_issuer = sanitize_issuer_for_json(issuer);
-        issuers_obj[sanitized_issuer] = picojson::value(issuer_obj);
+    // Issuers beyond MAX_TRACKED_ISSUERS share one aggregate bucket
+    if (m_overflow_stats.has_activity()) {
+        issuers_obj["<other>"] =
+            picojson::value(serialize_issuer_stats(m_overflow_stats));
     }
 
     root["issuers"] = picojson::value(issuers_obj);
@@ -182,6 +186,7 @@ void MonitoringStats::reset() {
     for (auto &entry : m_issuer_stats) {
         entry.second.reset_counters();
     }
+    m_overflow_stats.reset_counters();
     // The failed-issuer map stores plain values that are only accessed
     // under m_mutex, so clearing it is safe.
     m_failed_issuer_lookups.clear();

--- a/src/scitokens_monitoring.cpp
+++ b/src/scitokens_monitoring.cpp
@@ -83,6 +83,13 @@ std::string MonitoringStats::get_json() const {
         const std::string &issuer = entry.first;
         const IssuerStats &stats = entry.second;
 
+        // Entries survive reset() with zeroed counters (in-flight
+        // validations may hold references to them); don't report them
+        // until they see activity again.
+        if (!stats.has_activity()) {
+            continue;
+        }
+
         picojson::object issuer_obj;
         issuer_obj["successful_validations"] =
             picojson::value(static_cast<int64_t>(
@@ -166,7 +173,17 @@ std::string MonitoringStats::get_json() const {
 
 void MonitoringStats::reset() {
     std::lock_guard<std::mutex> lock(m_mutex);
-    m_issuer_stats.clear();
+    // Never erase IssuerStats entries: get_issuer_stats() hands out
+    // references that in-flight validations hold across the whole
+    // verification (its contract promises they live as long as the
+    // singleton).  Erasing them here would be a use-after-free for any
+    // concurrent verify(); zero the counters in place instead.  Entries
+    // with all-zero counters are omitted from get_json().
+    for (auto &entry : m_issuer_stats) {
+        entry.second.reset_counters();
+    }
+    // The failed-issuer map stores plain values that are only accessed
+    // under m_mutex, so clearing it is safe.
     m_failed_issuer_lookups.clear();
 }
 


### PR DESCRIPTION
## Problem

`MonitoringStats::get_issuer_stats()` inserts a permanent ~200-byte entry keyed by the `iss` claim of any syntactically valid token — **before** the signature or issuer is validated (`verify_async` records `async_validations_started`, and `get_public_key_pem` records `expired_keys` for unknown issuers). An attacker replaying unsigned tokens with random issuer strings grows the map without bound.

The existing DDoS protection (`MAX_FAILED_ISSUERS = 100`) only covers the separate failed-lookup map — and its recording path (`record_failed_issuer_lookup`) is currently never called from anywhere, so it protects nothing.

## Fix

- Cap tracked issuers at `MAX_TRACKED_ISSUERS` (1000). Once at capacity, statistics for further issuers aggregate into a single shared overflow bucket, reported as `"<other>"` in the monitoring JSON.
- Entries are still never erased, preserving the reference stability that in-flight validations depend on (see #214).
- The per-issuer JSON serialization moves into a `serialize_issuer_stats()` helper so the overflow bucket reuses it; no change to the JSON schema for existing issuers.

**Note:** this branch is stacked on #214 (contains its commit) since both change `MonitoringStats` internals — merging #214 first makes this a clean one-commit diff.

## Testing

- `ctest` unit, env_config, and monitoring suites pass (the monitoring suite exercises stats collection, JSON output, and reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)