### PR TITLE
Never block on the per-issuer fetch lock in the async path

### DIFF
--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -1117,14 +1117,27 @@ Validator::get_public_key_pem(const std::string &issuer, const std::string &kid,
             internal::MonitoringStats::instance().get_issuer_stats(issuer);
         issuer_stats.inc_expired_key();
 
-        // Use per-issuer lock to prevent thundering herd for new issuers
+        // Use per-issuer lock to prevent thundering herd for new issuers.
+        // Never block on the mutex: the async API can interleave several
+        // operations on one thread, and an earlier in-flight AsyncStatus for
+        // this issuer may already hold it -- a blocking acquire would
+        // deadlock the thread against itself (std::mutex is not recursive).
         auto issuer_mutex = get_issuer_mutex(issuer);
-        std::unique_lock<std::mutex> issuer_lock(*issuer_mutex);
+        std::unique_lock<std::mutex> issuer_lock(*issuer_mutex,
+                                                 std::try_to_lock);
 
-        // Check again if keys are now in DB (another thread may have fetched
-        // them while we were waiting for the lock)
-        if (get_public_keys_from_db(issuer, now, result->m_keys,
-                                    result->m_next_update)) {
+        if (!issuer_lock.owns_lock()) {
+            // Another operation is already fetching this issuer's keys.
+            // Return a status that polls the keycache DB (and retries the
+            // lock) on each continue call instead of blocking here.
+            result->m_waiting_for_issuer = true;
+            result->m_continue_fetch = true;
+            result->m_issuer_mutex = issuer_mutex;
+        }
+        // Check again if keys are now in DB (another operation may have
+        // fetched them before we acquired the lock)
+        else if (get_public_keys_from_db(issuer, now, result->m_keys,
+                                         result->m_next_update)) {
             // Keys are now available, use them
             result->m_continue_fetch = false;
             result->m_do_store = false;
@@ -1154,6 +1167,40 @@ std::unique_ptr<AsyncStatus>
 Validator::get_public_key_pem_continue(std::unique_ptr<AsyncStatus> status,
                                        std::string &public_pem,
                                        std::string &algorithm) {
+
+    if (status->m_waiting_for_issuer) {
+        // Another operation held this issuer's fetch lock when we started.
+        // See if it has stored keys in the meantime; a negative-cache entry
+        // (the other fetch failed) propagates as an exception here.
+        auto now = std::time(NULL);
+        if (get_public_keys_from_db(status->m_issuer, now, status->m_keys,
+                                    status->m_next_update)) {
+            status->m_waiting_for_issuer = false;
+            status->m_continue_fetch = false;
+            status->m_do_store = false;
+            // Fall through to the key-extraction code below.
+        } else {
+            // No keys yet: try to take over the fetch in case the other
+            // operation failed or was abandoned without storing anything.
+            std::unique_lock<std::mutex> issuer_lock(*status->m_issuer_mutex,
+                                                     std::try_to_lock);
+            if (!issuer_lock.owns_lock()) {
+                // Still fetching; poll again on the next continue call.
+                return std::move(status);
+            }
+            std::string issuer = status->m_issuer;
+            std::string kid = status->m_kid;
+            auto issuer_mutex = status->m_issuer_mutex;
+            status = get_public_keys_from_web(
+                issuer, internal::SimpleCurlGet::default_timeout);
+            status->m_issuer = issuer;
+            status->m_kid = kid;
+            status->m_issuer_mutex = issuer_mutex;
+            status->m_issuer_lock = std::move(issuer_lock);
+            // Fall through: the m_continue_fetch block below drives the
+            // download exactly as for a first-attempt fetch.
+        }
+    }
 
     if (status->m_continue_fetch) {
         // Save issuer and lock info before potentially moving status

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -852,13 +852,19 @@ class Validator {
                         "Timeout when loading the OIDC metadata.");
                 }
 
-                // Only continue if select returned due to I/O activity (not
-                // timeout)
-                if (select_result > 0) {
+                // Continue on I/O activity (select_result > 0) and also on
+                // timeout (select_result == 0): libcurl requires
+                // curl_multi_perform to be called after a select timeout so
+                // it can drive non-socket work (DNS retries, connect
+                // timeouts, internal timers).  A timed-out select also
+                // clears the fd_sets, and only verify_async_continue()
+                // repopulates them, so skipping it would leave this loop
+                // selecting on empty sets until expiry_time.
+                if (select_result >= 0) {
                     result = verify_async_continue(std::move(result));
                 }
-                // If select_result == 0 (timeout) or -1 (error/interrupt),
-                // just loop back to update duration and check expiry
+                // If select_result == -1 (error/interrupt), just loop back
+                // to update duration and check expiry
             }
 
             // Record successful validation (final duration update)

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -578,6 +578,9 @@ class AsyncStatus {
     bool m_has_metadata{false};
     bool m_oauth_fallback{false};
     bool m_is_refresh{false}; // True if this is a refresh of an existing key
+    // True if another operation holds this issuer's fetch lock; we poll the
+    // keycache DB on each continue instead of blocking on the mutex.
+    bool m_waiting_for_issuer{false};
     AsyncState m_state{DOWNLOAD_METADATA};
     std::unique_lock<std::mutex> m_refresh_lock;
     // Per-issuer lock to prevent thundering herd on new issuers
@@ -603,8 +606,14 @@ class AsyncStatus {
     struct timeval get_timeout_val(time_t expiry_time) const {
         auto now = time(NULL);
         long timeout_ms = 100 * (expiry_time - now);
-        if (m_cget && (m_cget->get_timeout_ms() < timeout_ms))
-            timeout_ms = m_cget->get_timeout_ms();
+        if (m_cget) {
+            if (m_cget->get_timeout_ms() < timeout_ms)
+                timeout_ms = m_cget->get_timeout_ms();
+        } else if (timeout_ms > 100) {
+            // No transfer of our own in progress (e.g. waiting for another
+            // operation's fetch of this issuer); poll at 100ms.
+            timeout_ms = 100;
+        }
         struct timeval timeout;
         timeout.tv_sec = timeout_ms / 1000;
         timeout.tv_usec = (timeout_ms % 1000) * 1000;


### PR DESCRIPTION
## Problem

For a new issuer, `get_public_key_pem()` acquires the per-issuer thundering-herd mutex (#180) with a **blocking** `std::unique_lock` and parks the held lock inside the returned `AsyncStatus` until the fetch completes.

The async API exists so an event loop can interleave several operations on one thread. If that thread calls `scitoken_deserialize_start` for a second token from the same still-fetching issuer, it blocks forever on a non-recursive mutex held by its own earlier status — a self-deadlock. Even across threads, a supposedly non-blocking `_start` call blocks for the full duration of another thread's web fetch.

## Fix

- Acquire the per-issuer mutex with `try_to_lock`.
- On failure, return a status in a new *waiting* state (`m_waiting_for_issuer`). Each `continue` call then:
  1. polls the keycache DB for the keys the lock holder is fetching (a negative-cache entry from a failed fetch propagates as an exception, as before), and
  2. retries the lock so a waiter can take over the fetch if the holder failed or was abandoned without storing anything.
- `get_timeout_val()` suggests a 100 ms poll interval while waiting, so both the sync select() loop and C-API event loops wake up promptly.

Thundering-herd protection is preserved: concurrent operations for the same new issuer still produce a single web fetch, with waiters picking the keys up from the keycache.

**Note:** stacked on #211 (contains its commit) — the sync `verify()` loop only re-polls on select timeout with that fix in place.

## Testing

- `ctest` unit, env_config, and monitoring suites pass (includes the async deserialize tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)