### PR TITLE
Fall back to still-valid cached keys when a JWKS refresh fails

### DIFF
--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -1090,10 +1090,16 @@ Validator::get_public_key_pem(const std::string &issuer, const std::string &kid,
                 internal::MonitoringStats::instance().get_issuer_stats(issuer);
             // Record that we're using a stale key (past next_update)
             issuer_stats.inc_stale_key_use();
+            // Save the still-valid cached keys so a failed refresh can fall
+            // back to them instead of failing the validation.
+            picojson::value cached_keys = result->m_keys;
             try {
-                result->m_ignore_error = true;
                 result = get_public_keys_from_web(
                     issuer, internal::SimpleCurlGet::default_timeout);
+                // A refresh failure is not fatal: we have valid keys already
+                result->m_ignore_error = true;
+                result->m_fallback_keys = cached_keys;
+                result->m_has_fallback_keys = true;
                 // Hold refresh mutex in the new result
                 result->m_refresh_lock = std::move(lock);
                 // Mark that this is a refresh attempt for a known issuer
@@ -1156,11 +1162,21 @@ Validator::get_public_key_pem_continue(std::unique_ptr<AsyncStatus> status,
                                        std::string &algorithm) {
 
     if (status->m_continue_fetch) {
-        // Save issuer and lock info before potentially moving status
+        // Save issuer, lock, and refresh-fallback info before potentially
+        // moving status: if the fetch throws, the status object (moved into
+        // the callee) is destroyed during unwinding.
         std::string issuer = status->m_issuer;
+        std::string kid = status->m_kid;
         auto issuer_mutex = status->m_issuer_mutex;
         std::unique_lock<std::mutex> issuer_lock(
             std::move(status->m_issuer_lock));
+        bool ignore_error = status->m_ignore_error;
+        bool has_fallback_keys = status->m_has_fallback_keys;
+        picojson::value fallback_keys = status->m_fallback_keys;
+        std::string jwt_string = status->m_jwt_string;
+        bool monitoring_started = status->m_monitoring_started;
+        bool is_sync = status->m_is_sync;
+        auto start_time = status->m_start_time;
 
         try {
             status = get_public_keys_from_web_continue(std::move(status));
@@ -1195,7 +1211,30 @@ Validator::get_public_key_pem_continue(std::unique_ptr<AsyncStatus> status,
                 }
                 issuer_lock.unlock();
             }
-            throw; // Re-throw the original exception
+            if (ignore_error && has_fallback_keys) {
+                // This was a refresh of keys that are still valid; fall
+                // back to them rather than failing the validation.  The
+                // keycache entry is untouched, so the next validation past
+                // next_update will retry the refresh.
+                auto &issuer_stats =
+                    internal::MonitoringStats::instance().get_issuer_stats(
+                        issuer);
+                issuer_stats.inc_failed_refresh();
+                std::unique_ptr<AsyncStatus> fallback(new AsyncStatus());
+                fallback->m_keys = fallback_keys;
+                fallback->m_issuer = issuer;
+                fallback->m_kid = kid;
+                fallback->m_do_store = false;
+                // Carry over verification state from the destroyed status
+                fallback->m_jwt_string = jwt_string;
+                fallback->m_monitoring_started = monitoring_started;
+                fallback->m_is_sync = is_sync;
+                fallback->m_start_time = start_time;
+                status = std::move(fallback);
+                // Fall through to the key-extraction code below.
+            } else {
+                throw; // Re-throw the original exception
+            }
         }
     }
     if (status->m_do_store) {

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -588,6 +588,11 @@ class AsyncStatus {
     int64_t m_next_update{-1};
     int64_t m_expires{-1};
     picojson::value m_keys;
+    // Still-valid cached keys saved before a refresh attempt; if the
+    // refresh fails (m_ignore_error set), validation falls back to these
+    // instead of failing outright.
+    picojson::value m_fallback_keys;
+    bool m_has_fallback_keys{false};
     std::string m_issuer;
     std::string m_kid;
     std::string m_oauth_metadata_url;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -691,8 +691,8 @@ TEST_F(SerializeTest, StaleKeyFallbackTest) {
     const char stale_issuer[] = "https://127.0.0.1:1/gtest-stale";
 
     // Store valid keys that become due for refresh after one second.
-    auto rv = scitoken_config_set_int("keycache.update_interval_s", 1,
-                                      &err_msg);
+    auto rv =
+        scitoken_config_set_int("keycache.update_interval_s", 1, &err_msg);
     ASSERT_TRUE(rv == 0) << err_msg;
     rv = scitoken_store_public_ec_key(stale_issuer, "1", ec_public, &err_msg);
     ASSERT_TRUE(rv == 0) << err_msg;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -683,6 +683,46 @@ TEST_F(SerializeTest, DeserializeAsyncTest) {
     scitoken_destroy(scitoken);
 }
 
+TEST_F(SerializeTest, StaleKeyFallbackTest) {
+    char *err_msg = nullptr;
+
+    // An issuer whose metadata endpoint can never be reached (connection
+    // is refused immediately; no network access is performed).
+    const char stale_issuer[] = "https://127.0.0.1:1/gtest-stale";
+
+    // Store valid keys that become due for refresh after one second.
+    auto rv = scitoken_config_set_int("keycache.update_interval_s", 1,
+                                      &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+    rv = scitoken_store_public_ec_key(stale_issuer, "1", ec_public, &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+    rv = scitoken_config_set_int("keycache.update_interval_s", 600, &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+
+    auto token = TokenPtr(scitoken_create(m_key.get()), scitoken_destroy);
+    ASSERT_TRUE(token.get() != nullptr);
+    rv = scitoken_set_claim_string(token.get(), "iss", stale_issuer, &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+    scitoken_set_lifetime(token.get(), 60);
+
+    char *token_value = nullptr;
+    rv = scitoken_serialize(token.get(), &token_value, &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+    std::unique_ptr<char, decltype(&free)> token_value_ptr(token_value, free);
+
+    // Let next_update pass so verification triggers a refresh attempt.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    // The refresh fetch fails (unreachable issuer), but the cached keys
+    // are still valid: verification must fall back to them and succeed.
+    rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr,
+                                 &err_msg);
+    EXPECT_TRUE(rv == 0) << (err_msg ? err_msg : "");
+    if (err_msg) {
+        free(err_msg);
+    }
+}
+
 TEST_F(SerializeTest, FailDeserializeAsyncTest) {
     char *err_msg = nullptr;
 


### PR DESCRIPTION
## Problem

When cached keys pass `next_update`, verification starts a refresh and sets `m_ignore_error = true`, intending to tolerate refresh failure — the cached keys remain valid until their much later expiry (default: refresh every 600 s, keys valid 4 days).

That flag is broken twice over:

1. It's set on the **old** status object, which is immediately replaced by `get_public_keys_from_web()`'s freshly-constructed status — so the flag is lost.
2. Nothing ever reads `m_ignore_error` anyway (`grep` confirms the only reference is the assignment).

The existing `catch` only covers a *synchronous* failure inside `perform_start()`. Once the refresh continues asynchronously (the normal case for network I/O), any failure — issuer briefly down, timeout, bad response — propagates out of `verify()` and **fails the validation despite valid cached keys**, defeating the stale-key tolerance the keycache is designed for.

## Fix

- Carry the flag plus the still-valid cached keys onto the refresh status (`m_fallback_keys`).
- In `get_public_key_pem_continue`, save the fallback state in locals before calling into the fetch (the status object is destroyed during unwinding if it throws), and on failure fall back to the cached keys — recording `failed_refreshes` in the monitoring stats — instead of rethrowing.
- The keycache entry is untouched, so the next validation past `next_update` retries the refresh.

## Testing

- New regression test `SerializeTest.StaleKeyFallbackTest`: stores valid keys for an unreachable issuer (`https://127.0.0.1:1`, connection refused — no external network) with a 1-second update interval, so verification triggers an **asynchronously failing** refresh. Verified the test fails without the fix and passes with it.
- `ctest` unit, env_config, and monitoring suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)