### PR TITLE
Document that SciToken/Validator/Enforcer handles are not thread-safe

### DIFF
--- a/src/scitokens.h
+++ b/src/scitokens.h
@@ -1,7 +1,18 @@
 /**
  * Public header for the SciTokens C library.
  *
+ * Thread-safety: individual handles (SciToken, SciTokenKey, Validator,
+ * Enforcer, SciTokenStatus) are NOT thread-safe.  A handle must not be
+ * used from multiple threads concurrently: validation mutates internal
+ * state on the Validator/Enforcer (detected token profile, requested
+ * test path, generated ACLs), so concurrent use of one handle can crash
+ * or -- worse -- return authorization results computed from another
+ * thread's request.  Create one handle per thread, or serialize access
+ * to a shared handle externally.
  *
+ * Distinct handles may be used from different threads freely: the
+ * shared key cache, configuration, and monitoring state are internally
+ * synchronized.
  */
 
 #include <sys/select.h>
@@ -244,6 +255,9 @@ int scitoken_store_public_ec_key(const char *issuer, const char *keyid,
 /**
  * @brief Create a new token validator
  *
+ * The returned handle is not thread-safe; do not call validator_*
+ * functions on the same handle from multiple threads concurrently.
+ *
  * @return Validator handle on success, NULL on failure
  */
 Validator validator_create();
@@ -285,6 +299,12 @@ void validator_destroy(Validator validator);
 
 /**
  * @brief Create a new token enforcer
+ *
+ * The returned handle is not thread-safe: enforcer_test and
+ * enforcer_generate_acls store the request being evaluated inside the
+ * handle, so concurrent calls on one handle can return authorization
+ * results computed from another thread's request.  Create one enforcer
+ * per thread, or serialize access externally.
  *
  * @param issuer Required issuer URL for tokens
  * @param audience NULL-terminated array of acceptable audience values


### PR DESCRIPTION
## Problem

Nothing in the public header states the thread-safety contract of the API handles — and it matters more than usual here:

- `Validator` mutates internal state during verification (`m_profile`, the detected token profile).
- `Enforcer` stores the request being evaluated inside the handle: `enforcer_test`/`enforcer_generate_acls` write `m_test_path`/`m_test_authz`/`m_gen_acls`, and the `scope_validator` callback reads them back mid-verification.

Two threads sharing one `Enforcer` can therefore race so that thread A's authorization test is evaluated against thread B's requested path — a **wrong authorization decision**, not merely a crash. Given the library's consumers are heavily threaded (XRootD et al.), this deserves an explicit statement.

## Change

Documentation only, in `scitokens.h`:

- Header preamble: handles are not thread-safe; one handle per thread or external serialization. Distinct handles are safe concurrently (key cache, configuration, and monitoring state are internally synchronized).
- Pointed notes on `validator_create` and `enforcer_create`, with the enforcer note explaining *why* (request state lives in the handle).

Making the `Enforcer` actually thread-safe (moving per-request state into the async status / stack) would be a larger behavioral change, best done separately if desired.

## Testing

- Comment-only change; library builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)