### PR TITLE
Fix several memory-safety issues in the C API surface

### DIFF
--- a/src/scitokens.cpp
+++ b/src/scitokens.cpp
@@ -180,6 +180,13 @@ void scitoken_key_destroy(SciTokenKey token) {
 SciToken scitoken_create(SciTokenKey private_key) {
     scitokens::SciTokenKey *key =
         reinterpret_cast<scitokens::SciTokenKey *>(private_key);
+    if (key == nullptr) {
+        // A key is only needed for signing; tokens used for deserialization
+        // may be created without one.  (Dereferencing the null handle here
+        // was previously undefined behavior.)
+        scitokens::SciTokenKey empty_key;
+        return new scitokens::SciToken(empty_key);
+    }
     return new scitokens::SciToken(*key);
 }
 
@@ -252,6 +259,24 @@ int scitoken_get_claim_string(const SciToken token, const char *key,
                               char **value, char **err_msg) {
     scitokens::SciToken *real_token =
         reinterpret_cast<scitokens::SciToken *>(token);
+    if (real_token == nullptr) {
+        if (err_msg) {
+            *err_msg = strdup("Token passed is not initialized.");
+        }
+        return -1;
+    }
+    if (key == nullptr) {
+        if (err_msg) {
+            *err_msg = strdup("Claim key passed is not initialized.");
+        }
+        return -1;
+    }
+    if (value == nullptr) {
+        if (err_msg) {
+            *err_msg = strdup("Output value pointer may not be null.");
+        }
+        return -1;
+    }
     std::string claim_str;
     try {
         claim_str = real_token->get_claim_string(key);
@@ -307,9 +332,16 @@ int scitoken_get_claim_string_list(const SciToken token, const char *key,
         }
         return -1;
     }
+    // calloc null-initializes every slot, so a partially-filled list is
+    // always terminated and safe to hand to scitoken_free_string_list.
     auto claim_list_c =
-        static_cast<char **>(malloc(sizeof(char *) * (claim_list.size() + 1)));
-    claim_list_c[claim_list.size()] = nullptr;
+        static_cast<char **>(calloc(claim_list.size() + 1, sizeof(char *)));
+    if (claim_list_c == nullptr) {
+        if (err_msg) {
+            *err_msg = strdup("Failed to allocate string list");
+        }
+        return -1;
+    }
     int idx = 0;
     for (const auto &entry : claim_list) {
         claim_list_c[idx] = strdup(entry.c_str());
@@ -328,10 +360,14 @@ int scitoken_get_claim_string_list(const SciToken token, const char *key,
 }
 
 void scitoken_free_string_list(char **value) {
-    int idx = 0;
-    do {
-        free(value[idx++]);
-    } while (value[idx]);
+    if (value == nullptr) {
+        return;
+    }
+    // Note: the previous do/while formulation read value[idx] after the
+    // terminating nullptr on an empty list (heap out-of-bounds read).
+    for (int idx = 0; value[idx]; idx++) {
+        free(value[idx]);
+    }
     free(value);
 }
 
@@ -724,12 +760,21 @@ void enforcer_set_validate_profile(Enforcer enf, SciTokenProfile profile) {
 namespace {
 
 Acl *convert_acls(scitokens::Enforcer::AclsList &acls_list, char **err_msg) {
+    // calloc null-initializes every entry (including the terminator), so a
+    // partially-filled array is always safe to hand to enforcer_acl_free;
+    // the previous malloc left the tail uninitialized, and the error paths
+    // below freed uninitialized pointers.
     Acl *acl_result =
-        static_cast<Acl *>(malloc((acls_list.size() + 1) * sizeof(Acl)));
+        static_cast<Acl *>(calloc(acls_list.size() + 1, sizeof(Acl)));
+    if (acl_result == nullptr) {
+        if (err_msg) {
+            *err_msg = strdup("Failed to allocate the ACL list.");
+        }
+        return nullptr;
+    }
     size_t idx = 0;
     for (const auto &acl : acls_list) {
         acl_result[idx].authz = strdup(acl.first.c_str());
-        acl_result[idx].resource = strdup(acl.second.c_str());
         if (acl_result[idx].authz == nullptr) {
             enforcer_acl_free(acl_result);
             if (err_msg) {
@@ -738,6 +783,7 @@ Acl *convert_acls(scitokens::Enforcer::AclsList &acls_list, char **err_msg) {
             }
             return nullptr;
         }
+        acl_result[idx].resource = strdup(acl.second.c_str());
         if (acl_result[idx].resource == nullptr) {
             enforcer_acl_free(acl_result);
             if (err_msg) {
@@ -747,8 +793,6 @@ Acl *convert_acls(scitokens::Enforcer::AclsList &acls_list, char **err_msg) {
         }
         idx++;
     }
-    acl_result[idx].authz = nullptr;
-    acl_result[idx].resource = nullptr;
     return acl_result;
 }
 

--- a/src/scitokens_cache.cpp
+++ b/src/scitokens_cache.cpp
@@ -340,6 +340,13 @@ bool scitokens::Validator::get_public_keys_from_db(const std::string issuer,
     rc = sqlite3_step(stmt);
     if (rc == SQLITE_ROW) {
         const unsigned char *data = sqlite3_column_text(stmt, 0);
+        if (data == nullptr) {
+            // Out-of-memory or unexpected NULL; constructing a std::string
+            // from a null pointer is undefined behavior.
+            sqlite3_finalize(stmt);
+            sqlite3_close(db);
+            return false;
+        }
         std::string metadata(reinterpret_cast<const char *>(data));
         sqlite3_finalize(stmt);
         picojson::value json_obj;
@@ -666,6 +673,11 @@ std::string scitokens::Validator::get_jwks_metadata(const std::string &issuer) {
     rc = sqlite3_step(stmt);
     if (rc == SQLITE_ROW) {
         const unsigned char *data = sqlite3_column_text(stmt, 0);
+        if (data == nullptr) {
+            sqlite3_finalize(stmt);
+            sqlite3_close(db);
+            throw std::runtime_error("Failed to read cache entry");
+        }
         std::string metadata(reinterpret_cast<const char *>(data));
         sqlite3_finalize(stmt);
         sqlite3_close(db);

--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -1413,8 +1413,13 @@ bool scitokens::Enforcer::scope_validator(const jwt::claim &claim,
     // me->m_test_authz << ":" << requested_path << std::endl;
     bool compat_modify = false, compat_create = false, compat_cancel = false;
     while (scope_iter != scope.end()) {
-        while (*scope_iter == ' ') {
+        while (scope_iter != scope.end() && *scope_iter == ' ') {
             scope_iter++;
+        }
+        if (scope_iter == scope.end()) {
+            // Trailing whitespace: previously this dereferenced end() and
+            // then emitted a bogus ACL with an empty authorization.
+            break;
         }
         auto next_scope_iter = std::find(scope_iter, scope.end(), ' ');
         std::string full_authz;

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -661,7 +661,10 @@ class SciToken {
         m_deserialize_profile = profile;
     }
 
-    const jwt::claim get_claim(const std::string &key) { return m_claims[key]; }
+    const jwt::claim get_claim(const std::string &key) {
+        auto iter = m_claims.find(key);
+        return iter == m_claims.end() ? jwt::claim() : iter->second;
+    }
 
     bool has_claim(const std::string &key) const {
         return m_claims.find(key) != m_claims.end();
@@ -678,16 +681,16 @@ class SciToken {
     }
 
     // Return a claim as a string
-    // If the claim is not a string, it can throw
+    // If the claim is not a string (or not present), it can throw
     // a std::bad_cast() exception.
     const std::string get_claim_string(const std::string &key) {
-        return m_claims[key].as_string();
+        return get_claim(key).as_string();
     }
 
     const std::vector<std::string> get_claim_list(const std::string &key) {
         picojson::array array;
         try {
-            array = m_claims[key].as_array();
+            array = get_claim(key).as_array();
         } catch (std::bad_cast &) {
             throw JsonException("Claim's value is not a JSON list");
         }
@@ -761,7 +764,10 @@ class SciToken {
     Profile m_deserialize_profile{Profile::COMPAT};
     std::unordered_map<std::string, jwt::claim> m_claims;
     std::unique_ptr<jwt::decoded_jwt<jwt::traits::kazuho_picojson>> m_decoded;
-    SciTokenKey &m_key;
+    // Owned by value: scitoken_deserialize (and callers that destroy the
+    // key handle before serializing) previously left a dangling reference
+    // here to a stack- or heap-allocated key.
+    SciTokenKey m_key;
 };
 
 class Validator {

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -396,6 +396,73 @@ TEST_F(SerializeTest, EnforcerScopeTest) {
     ASSERT_TRUE(found_write);
 }
 
+TEST_F(SerializeTest, EnforcerScopeTrailingSpaceTest) {
+    char *err_msg = nullptr;
+
+    auto rv = scitoken_set_claim_string(
+        m_token.get(), "aud", "https://demo.scitokens.org/", &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+
+    auto enforcer = enforcer_create("https://demo.scitokens.org/gtest",
+                                    &m_audiences_array[0], &err_msg);
+    ASSERT_TRUE(enforcer != nullptr) << err_msg;
+
+    // Trailing whitespace previously walked the iterator past end() and
+    // emitted a bogus ACL with an empty authorization.
+    rv = scitoken_set_claim_string(m_token.get(), "scope", "read:/foo ",
+                                   &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+
+    rv = scitoken_set_claim_string(m_token.get(), "ver", "scitoken:2.0",
+                                   &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+
+    char *token_value = nullptr;
+    rv = scitoken_serialize(m_token.get(), &token_value, &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+
+    rv = scitoken_deserialize_v2(token_value, m_read_token.get(), nullptr,
+                                 &err_msg);
+    free(token_value);
+    ASSERT_TRUE(rv == 0) << err_msg;
+
+    Acl *acls;
+    rv = enforcer_generate_acls(enforcer, m_read_token.get(), &acls, &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+    ASSERT_TRUE(acls != nullptr);
+    int count = 0;
+    for (int idx = 0; acls[idx].authz || acls[idx].resource; idx++) {
+        EXPECT_STREQ(acls[idx].authz, "read");
+        EXPECT_STREQ(acls[idx].resource, "/foo");
+        count++;
+    }
+    EXPECT_EQ(count, 1);
+    enforcer_acl_free(acls);
+    enforcer_destroy(enforcer);
+}
+
+TEST_F(SerializeTest, EmptyStringListTest) {
+    char *err_msg = nullptr;
+
+    // A claim whose value is an empty JSON list: freeing the returned
+    // (terminator-only) string list previously read past the allocation.
+    const char *empty_list[1] = {nullptr};
+    auto rv = scitoken_set_claim_string_list(m_token.get(), "empty_groups",
+                                             empty_list, &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+
+    char **value = nullptr;
+    rv = scitoken_get_claim_string_list(m_token.get(), "empty_groups", &value,
+                                        &err_msg);
+    ASSERT_TRUE(rv == 0) << err_msg;
+    ASSERT_TRUE(value != nullptr);
+    EXPECT_EQ(value[0], nullptr);
+    scitoken_free_string_list(value);
+
+    // Null input is a no-op.
+    scitoken_free_string_list(nullptr);
+}
+
 TEST_F(SerializeTest, EnforcerScopeRespectsPathBoundaries) {
     char *err_msg = nullptr;
 


### PR DESCRIPTION
A bundle of small, related memory-safety fixes found while auditing the C API:

## Out-of-bounds / uninitialized memory
- **`scitoken_free_string_list`**: the `do/while` read `value[idx]` *after* the terminating NULL — for an empty (terminator-only) list this reads one element past the allocation. Rewritten as a bounded loop; NULL input is now a no-op.
- **`convert_acls`**: `malloc`'d array was filled left-to-right with the tail (including the terminator) uninitialized; on `strdup` failure the cleanup handed uninitialized pointers to `enforcer_acl_free` (wild frees). Now uses checked `calloc` and checks each `strdup` before proceeding.
- **`scitoken_get_claim_string_list`**: unchecked `malloc` → checked `calloc` (partially-built lists always terminated).

## Null-pointer UB
- **`scitoken_get_claim_string`** dereferenced a NULL token handle — the only getter without the standard NULL check. Also rejects null `key`/`value`.
- **`scitoken_create(NULL)`** bound a C++ reference through a null pointer (UB; the test suite itself calls this). Now constructs with an empty key, matching the header's documented *"NULL for unsigned token"*.
- **`sqlite3_column_text`** results were passed to `std::string(const char*)` without a null check in `get_public_keys_from_db` and `get_jwks_metadata` (the third call site already checks).

## Dangling reference
- **`SciToken` stored its signing key as `SciTokenKey&`**. `scitoken_deserialize` passes a *stack-local* key, so the returned token held a dangling reference — `scitoken_serialize` after deserialize read dead stack memory. Same for callers destroying their key handle before serializing. The key is now owned by value (four small strings; keys have no mutators, so no behavior change).
- **`SciToken::get_claim*`** used `operator[]`, silently inserting empty claims into the token on every lookup miss; now uses `find()`.

## Iterator UB
- **`Enforcer::scope_validator`** walked its iterator past `scope.end()` on trailing whitespace, and then emitted a bogus ACL with an *empty authorization string* into `generate_acls` output.

## Testing
- New regression tests: `EnforcerScopeTrailingSpaceTest` (exactly one ACL from `"read:/foo "`) and `EmptyStringListTest` (empty list round-trip + free).
- `ctest` unit, env_config, and monitoring suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)