### PR TITLE
Construct refresh-thread dependencies before the manager singleton

### DIFF
--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -86,6 +86,26 @@ std::once_flag Validator::m_background_refresh_once;
 namespace internal {
 
 // BackgroundRefreshManager implementation
+BackgroundRefreshManager &BackgroundRefreshManager::get_instance() {
+    // Construct the singletons and function-local statics the refresh
+    // thread uses BEFORE constructing this instance.  Objects with static
+    // storage duration are destroyed in the reverse order their
+    // construction completed, so everything constructed here is guaranteed
+    // to outlive the manager -- whose destructor stops and joins the
+    // thread.  Without this ordering, a dependency first touched after the
+    // manager was created would be destroyed before it at exit, while the
+    // refresh thread may still be using it (a use-after-destruction race
+    // during shutdown).
+    MonitoringStats::instance();
+    configurer::Configuration::get_cache_home();
+    configurer::Configuration::get_tls_ca_file();
+    configurer::Configuration::get_next_update_delta();
+    configurer::Configuration::get_expiry_delta();
+
+    static BackgroundRefreshManager instance;
+    return instance;
+}
+
 void BackgroundRefreshManager::start() {
     std::lock_guard<std::mutex> lock(m_mutex);
     if (m_running.load(std::memory_order_acquire)) {

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -164,10 +164,10 @@ bool get_keycache_location(std::string &cache_file,
  */
 class BackgroundRefreshManager {
   public:
-    static BackgroundRefreshManager &get_instance() {
-        static BackgroundRefreshManager instance;
-        return instance;
-    }
+    // Defined out-of-line: it constructs the singletons the refresh thread
+    // depends on before constructing this instance (see the implementation
+    // for the static destruction-order reasoning).
+    static BackgroundRefreshManager &get_instance();
 
     // Start the background refresh thread (can be called multiple times)
     void start();


### PR DESCRIPTION
## Problem

`BackgroundRefreshManager`'s destructor stops and joins the refresh thread, so the thread can be running right up until the manager singleton is destroyed during static destruction.

C++ destroys objects with static storage duration in reverse order of construction *completion*. If a dependency the thread uses — the `MonitoringStats` singleton, or a `Configuration` function-local static (cache-home mutex/string, etc.) — is first touched **after** the manager singleton was created (e.g., `keycache_set_background_refresh(1)` is the very first library call an application makes), that dependency is destroyed **before** the manager at exit, while the refresh thread may still be calling into it: a use-after-destruction race during shutdown.

## Fix

Move `get_instance()` out of line and have it construct the thread's dependencies (`MonitoringStats::instance()` and the `Configuration` accessors backed by function-local statics) before constructing the manager instance. Reverse-destruction order then guarantees they all outlive the thread join.

Namespace-scope globals the thread also touches (the `CurlRaii` init guard, the per-issuer mutex map, sqlite state) are dynamically initialized at library load — before any function-local static can be constructed — so they already outlive the manager.

## Testing

- `ctest` unit, env_config, and monitoring suites pass (the monitoring suite starts/stops the background refresh thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)