### PR TITLE
Evaluate token lifetimes against the current time by default

### DIFF
--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -780,7 +780,10 @@ class Validator {
   public:
     Validator() : m_now(std::chrono::system_clock::now()) {}
 
-    void set_now(std::chrono::system_clock::time_point now) { m_now = now; }
+    void set_now(std::chrono::system_clock::time_point now) {
+        m_now = now;
+        m_now_set = true;
+    }
 
     // Maximum timeout for select() in microseconds for periodic checks
     static constexpr long MAX_SELECT_TIMEOUT_US = 50000; // 50ms
@@ -1068,9 +1071,15 @@ class Validator {
         SciTokenKey key(status->m_kid, status->m_algorithm,
                         status->m_public_pem, "");
 
-        auto verifier =
-            jwt::verify<FixedClock, jwt::traits::kazuho_picojson>({m_now})
-                .allow_algorithm(key);
+        // Unless the caller explicitly pinned the clock with set_now(),
+        // evaluate exp/nbf against the current time.  Validators and
+        // Enforcers are frequently long-lived; freezing the clock at
+        // construction time made them accept arbitrarily expired tokens.
+        auto verification_time =
+            m_now_set ? m_now : std::chrono::system_clock::now();
+        auto verifier = jwt::verify<FixedClock, jwt::traits::kazuho_picojson>(
+                            {verification_time})
+                            .allow_algorithm(key);
 
         const jwt::decoded_jwt<jwt::traits::kazuho_picojson> jwt(
             status->m_jwt_string);
@@ -1412,6 +1421,9 @@ class Validator {
     ClaimValidatorMap m_claim_validators;
 
     std::chrono::system_clock::time_point m_now;
+    // True only when set_now() was called; otherwise each verification
+    // uses the current time.
+    bool m_now_set{false};
 
     std::vector<std::string> m_critical_claims;
     std::vector<std::string> m_allowed_issuers;


### PR DESCRIPTION
## Problem

`Validator` captures `std::chrono::system_clock::now()` **at construction** and uses that frozen instant (via `FixedClock`) to evaluate `exp`/`nbf` on every subsequent verification.

Validators and Enforcers are commonly constructed once and reused for the lifetime of a server process. Unless the caller remembers to call `validator_set_time`/`enforcer_set_time` before **every** use, a long-lived `Enforcer`:

- **accepts tokens that expired hours or days ago** (any token valid at enforcer-construction time stays valid forever), and
- rejects fresh tokens whose `nbf` is after the enforcer was created.

The first is a security issue: token expiration is the primary revocation mechanism in this ecosystem.

## Fix

Sample the clock at each verification unless the caller explicitly pinned it with `set_now()` (tracked by a new `m_now_set` flag). The documented *"validate as if at some time in the past"* feature (`validator_set_time`/`enforcer_set_time`) is fully preserved — the existing `ExplicitTime` test covers it.

## Behavior change

Callers who relied on the frozen construction-time clock (without calling `set_time`) will now see expired tokens correctly rejected. That is the safer default; flagging it here explicitly since it is technically observable.

## Testing

- `ctest` unit, env_config, and monitoring suites pass, including `SerializeTest.ExplicitTime` (pinned-clock path) and the expired-token rejection tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)