### PR TITLE
Cache the keycache location resolution instead of redoing it per operation

### DIFF
--- a/src/scitokens_cache.cpp
+++ b/src/scitokens_cache.cpp
@@ -151,7 +151,7 @@ void initialize_cachedb(const std::string &keycache_file) {
  *  4. If all of the above fail and keycache.allow_in_memory is true,
  *     fall back to a shared in-memory SQLite database
  */
-CacheLocationInfo resolve_cache_location() {
+CacheLocationInfo resolve_cache_location_uncached() {
     CacheLocationInfo location_info;
     const char *xdg_cache_home = getenv("XDG_CACHE_HOME");
 
@@ -212,6 +212,33 @@ CacheLocationInfo resolve_cache_location() {
     location_info.active_db_path = location_info.cache_file;
 
     return location_info;
+}
+
+// Resolving the location is expensive -- getpwuid_r, two mkdir calls, and a
+// full SQLite open/CREATE TABLE/close round trip -- and was previously
+// performed for every keycache operation (at least once per token
+// validation).  Cache the successful result; the cache is invalidated when
+// a configuration value affecting the location changes (cache home,
+// in-memory fallback).
+CacheLocationInfo resolve_cache_location() {
+    static std::mutex cache_mutex;
+    static CacheLocationInfo cached_info;
+    static bool cached_valid = false;
+    static uint64_t cached_generation = 0;
+
+    uint64_t generation =
+        configurer::Configuration::get_cache_config_generation();
+
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    if (cached_valid && cached_generation == generation) {
+        return cached_info;
+    }
+    cached_info = resolve_cache_location_uncached();
+    cached_generation = generation;
+    // Only cache successful resolutions: failures (transient permission or
+    // disk problems) should be retried on the next operation.
+    cached_valid = !cached_info.active_db_path.empty();
+    return cached_info;
 }
 
 std::string get_cache_file() { return resolve_cache_location().active_db_path; }
@@ -526,6 +553,10 @@ scitokens::Validator::get_all_issuers_from_db(int64_t now) {
         sqlite3_close(db);
         return result;
     }
+    // Set busy timeout to handle concurrent access; without it, a write
+    // from another thread/process makes the scan below silently return a
+    // partial issuer list.
+    sqlite3_busy_timeout(db, SQLITE_BUSY_TIMEOUT_MS);
 
     sqlite3_stmt *stmt;
     rc = sqlite3_prepare_v2(db, "SELECT issuer, keys FROM keycache", -1, &stmt,

--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -1491,9 +1491,12 @@ configurer::Configuration::set_cache_home(const std::string dir_path) {
     // If setting to "", then we should treat as though it is unsetting the
     // config
     if (dir_path.length() == 0) { // User is configuring to empty string
-        std::lock_guard<std::mutex> lock(get_cache_home_mutex());
-        get_cache_home_string() = dir_path;
-        get_cache_home_set().store(false, std::memory_order_relaxed);
+        {
+            std::lock_guard<std::mutex> lock(get_cache_home_mutex());
+            get_cache_home_string() = dir_path;
+            get_cache_home_set().store(false, std::memory_order_relaxed);
+        }
+        bump_cache_config_generation();
         return std::make_pair(true, "");
     }
 
@@ -1521,6 +1524,7 @@ configurer::Configuration::set_cache_home(const std::string dir_path) {
         get_cache_home_string() = cleaned_dir_path;
         get_cache_home_set().store(true, std::memory_order_relaxed);
     }
+    bump_cache_config_generation();
     return std::make_pair(true, "");
 }
 

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -65,9 +65,22 @@ class Configuration {
     // In-memory keycache fallback configuration
     static void set_allow_in_memory(bool enabled) {
         m_allow_in_memory.store(enabled, std::memory_order_relaxed);
+        bump_cache_config_generation();
     }
     static bool get_allow_in_memory() {
         return m_allow_in_memory.load(std::memory_order_relaxed);
+    }
+
+    // Generation counter for configuration changes that affect where the
+    // keycache lives (cache home, in-memory fallback).  The cached keycache
+    // location resolution is invalidated when this changes.
+    static uint64_t get_cache_config_generation() {
+        return get_cache_config_generation_ref().load(
+            std::memory_order_acquire);
+    }
+    static void bump_cache_config_generation() {
+        get_cache_config_generation_ref().fetch_add(1,
+                                                    std::memory_order_acq_rel);
     }
 
     // Background refresh configuration
@@ -121,6 +134,11 @@ class Configuration {
     }
     static std::atomic<bool> &get_tls_ca_file_set() {
         static std::atomic<bool> instance{false};
+        return instance;
+    }
+
+    static std::atomic<uint64_t> &get_cache_config_generation_ref() {
+        static std::atomic<uint64_t> instance{0};
         return instance;
     }
 


### PR DESCRIPTION
## Problem

`resolve_cache_location()` runs for **every** keycache operation — at least once per token validation, twice for validations that also store keys. Each call performs:

1. `getpwuid_r` (password-database lookup),
2. two `mkdir` calls,
3. a full SQLite **open / `CREATE TABLE IF NOT EXISTS` / close** round trip (`initialize_cachedb`),

…after which the caller opens the database a *second* time to do the actual query. That's two SQLite opens plus a DDL statement on the hot path of every validation, even with a warm cache.

## Fix

- Split the existing logic into `resolve_cache_location_uncached()` and a caching wrapper.
- The cache is invalidated via a generation counter that configuration changes affecting the location (`keycache.cache_home`, `keycache.allow_in_memory`) bump.
- Failed resolutions are **not** cached, so transient permission/disk problems keep being retried.

Also sets the SQLite busy timeout in `get_all_issuers_from_db()` — the only DB path missing it — so a concurrent write no longer makes the background refresher silently return a partial issuer list.

## Behavior note

A change to `$XDG_CACHE_HOME` after the first resolution is no longer picked up automatically (setting `keycache.cache_home` still invalidates immediately). Mutating the environment mid-process was of dubious reliability before.

## Testing

- `ctest` unit, env_config, and monitoring suites pass — including `SetGetConfiguredCacheHome`/`GetKeycacheLocation`, which change the cache home mid-run and exercise the invalidation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)