### PR TITLE
Trim fd_set memory, fix timeout math, stop busy-spinning in verify(jwt)

### DIFF
--- a/src/scitokens_internal.cpp
+++ b/src/scitokens_internal.cpp
@@ -265,11 +265,11 @@ SimpleCurlGet::GetStatus SimpleCurlGet::perform_continue() {
         if (m_timeout_ms < 0) {
             m_timeout_ms = 100;
         }
-        FD_ZERO(m_read_fd_set);
-        FD_ZERO(m_write_fd_set);
-        FD_ZERO(m_exc_fd_set);
-        resm = curl_multi_fdset(m_curl_multi.get(), m_read_fd_set,
-                                m_write_fd_set, m_exc_fd_set, &m_max_fd);
+        FD_ZERO(&m_read_fd_set);
+        FD_ZERO(&m_write_fd_set);
+        FD_ZERO(&m_exc_fd_set);
+        resm = curl_multi_fdset(m_curl_multi.get(), &m_read_fd_set,
+                                &m_write_fd_set, &m_exc_fd_set, &m_max_fd);
         if (resm) {
             throw CurlException(curl_multi_strerror(resm));
         }
@@ -320,7 +320,7 @@ int SimpleCurlGet::perform(const std::string &url, time_t expiry_time) {
         timeout.tv_sec = timeout_ms / 1000;
         timeout.tv_usec = (timeout_ms % 1000) * 1000;
         // Return value of select is ignored; curl will take care of it.
-        select(m_max_fd + 1, m_read_fd_set, m_write_fd_set, m_exc_fd_set,
+        select(m_max_fd + 1, &m_read_fd_set, &m_write_fd_set, &m_exc_fd_set,
                &timeout);
         status = perform_continue();
     }

--- a/src/scitokens_internal.h
+++ b/src/scitokens_internal.h
@@ -204,9 +204,12 @@ class SimpleCurlGet {
     size_t m_len{0};
     std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> m_curl;
     std::unique_ptr<CURLM, decltype(&curl_multi_cleanup)> m_curl_multi;
-    fd_set m_read_fd_set[FD_SETSIZE];
-    fd_set m_write_fd_set[FD_SETSIZE];
-    fd_set m_exc_fd_set[FD_SETSIZE];
+    // A single fd_set already holds FD_SETSIZE descriptors; these were
+    // previously declared as arrays of FD_SETSIZE fd_sets (~384KB of
+    // wasted memory per in-flight request).
+    fd_set m_read_fd_set;
+    fd_set m_write_fd_set;
+    fd_set m_exc_fd_set;
     int m_max_fd{-1};
     long m_timeout_ms{0};
 
@@ -232,9 +235,9 @@ class SimpleCurlGet {
 
     long get_timeout_ms() const { return m_timeout_ms; }
     int get_max_fd() const { return m_max_fd; }
-    fd_set *get_read_fd_set() { return m_read_fd_set; }
-    fd_set *get_write_fd_set() { return m_write_fd_set; }
-    fd_set *get_exc_fd_set() { return m_exc_fd_set; }
+    fd_set *get_read_fd_set() { return &m_read_fd_set; }
+    fd_set *get_write_fd_set() { return &m_write_fd_set; }
+    fd_set *get_exc_fd_set() { return &m_exc_fd_set; }
 
   private:
     static size_t write_data(void *buffer, size_t size, size_t nmemb,
@@ -602,7 +605,15 @@ class AsyncStatus {
 
     struct timeval get_timeout_val(time_t expiry_time) const {
         auto now = time(NULL);
-        long timeout_ms = 100 * (expiry_time - now);
+        // Note: this was `100 *`, suggesting a poll interval 10x more
+        // frequent than the seconds-to-milliseconds conversion used
+        // everywhere else.
+        long timeout_ms = 1000 * (expiry_time - now);
+        if (timeout_ms < 0) {
+            // Deadline already passed; a negative timeval is invalid for
+            // select() (EINVAL).
+            timeout_ms = 0;
+        }
         if (m_cget && (m_cget->get_timeout_ms() < timeout_ms))
             timeout_ms = m_cget->get_timeout_ms();
         struct timeval timeout;
@@ -920,6 +931,17 @@ class Validator {
             // Note: m_is_sync flag no longer needed since counting is only done
             // in verify_async_continue
             while (!result->m_done) {
+                // Wait for socket readiness (or curl's suggested timeout,
+                // capped at one second) instead of busy-spinning on
+                // curl_multi_perform for the duration of the key fetch.
+                auto timeout_val = result->get_timeout_val(time(NULL) + 1);
+                select(result->get_max_fd() + 1, result->get_read_fd_set(),
+                       result->get_write_fd_set(), result->get_exc_fd_set(),
+                       &timeout_val);
+                // Continue regardless of the select() result: libcurl
+                // requires curl_multi_perform after a timeout to drive its
+                // internal (non-socket) work, and a timed-out select clears
+                // the fd_sets, which only the continue call repopulates.
                 result = verify_async_continue(std::move(result));
             }
 


### PR DESCRIPTION
Three related I/O-loop cleanups:

## 1. ~384 KB of fd_sets per in-flight request

`SimpleCurlGet` declared its select() sets as `fd_set m_read_fd_set[FD_SETSIZE]` — an **array of 1024 `fd_set`s** (×3 members) where a single `fd_set` (which already holds `FD_SETSIZE` descriptors) was intended. Roughly 384 KB of wasted memory per `SimpleCurlGet`, i.e., per in-flight verification. It only worked because the arrays decayed to a pointer to their first element.

## 2. Timeout math in `AsyncStatus::get_timeout_val()`

Computed `100 * (seconds remaining)` where every other site converts seconds→ms with `1000` (compare `SimpleCurlGet::perform`). C-API event loops using `scitoken_status_get_timeout_val` therefore polled 10× more often than intended. It also produced a **negative `timeval`** once the deadline passed — invalid for `select()` (`EINVAL`). Now `1000 *` with a clamp at zero.

## 3. Busy-spin in `verify(jwt)`

The `verify(const jwt::decoded_jwt&)` overload — the path `scitoken_deserialize` uses — looped `verify_async_continue()` with **no `select()` at all**, pinning a CPU core for the full duration of any JWKS fetch over the network. It now waits on the transfer's descriptors (capped at 1 s) and continues unconditionally afterward, as libcurl requires after timeouts.

## Testing

- `ctest` unit, env_config, and monitoring suites pass (deserialize tests exercise the reworked loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)