### PR TITLE
Declare C++17 in CMake and implement scitokens-verify --profile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ pkg_check_modules(SQLITE REQUIRED sqlite3)
 endif()
 
 add_library(SciTokens SHARED src/scitokens.cpp src/scitokens_internal.cpp src/scitokens_cache.cpp src/scitokens_monitoring.cpp)
-target_compile_features(SciTokens PUBLIC cxx_std_11) # Use at least C++11 for building and when linking to scitokens
+target_compile_features(SciTokens PUBLIC cxx_std_17) # The sources use C++17 features (structured bindings, std::make_unique)
 target_include_directories(SciTokens PUBLIC ${JWT_CPP_INCLUDES} "${PROJECT_SOURCE_DIR}/src" PRIVATE ${CURL_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIRS} ${LIBCRYPTO_INCLUDE_DIRS} ${SQLITE_INCLUDE_DIRS}  ${UUID_INCLUDE_DIRS})
 
 # Find threading library

--- a/src/verify.cpp
+++ b/src/verify.cpp
@@ -122,13 +122,59 @@ int main(int argc, char *const *argv) {
         }
     }
 
-    SciToken scitoken;
     char *err_msg = nullptr;
-    if (scitoken_deserialize(token.c_str(), &scitoken, nullptr, &err_msg)) {
-        std::cout << "Failed to deserialize a token: " << err_msg << std::endl;
-        return 1;
+    SciToken scitoken = nullptr;
+    SciTokenKey dummy_key = nullptr;
+    if (g_profile.empty()) {
+        if (scitoken_deserialize(token.c_str(), &scitoken, nullptr,
+                                 &err_msg)) {
+            std::cout << "Failed to deserialize a token: " << err_msg
+                      << std::endl;
+            free(err_msg);
+            return 1;
+        }
+    } else {
+        // The --profile option restricts which token profile is acceptable;
+        // it requires creating the token object up front so the deserialize
+        // profile can be set before parsing.
+        SciTokenProfile profile;
+        if (g_profile == "wlcg") {
+            profile = SciTokenProfile::WLCG_1_0;
+        } else if (g_profile == "scitokens1") {
+            profile = SciTokenProfile::SCITOKENS_1_0;
+        } else if (g_profile == "scitokens2") {
+            profile = SciTokenProfile::SCITOKENS_2_0;
+        } else if (g_profile == "atjwt") {
+            profile = SciTokenProfile::AT_JWT;
+        } else {
+            fprintf(stderr, "%s: unknown token profile: %s\n", argv[0],
+                    g_profile.c_str());
+            return 1;
+        }
+
+        // No signing key is needed for verification.
+        dummy_key = scitoken_key_create("none", "none", "", "", &err_msg);
+        if (dummy_key == nullptr) {
+            fprintf(stderr, "%s: %s\n", argv[0], err_msg);
+            free(err_msg);
+            return 1;
+        }
+        scitoken = scitoken_create(dummy_key);
+        scitoken_set_deserialize_profile(scitoken, profile);
+        if (scitoken_deserialize_v2(token.c_str(), scitoken, nullptr,
+                                    &err_msg)) {
+            std::cout << "Failed to deserialize a token: " << err_msg
+                      << std::endl;
+            free(err_msg);
+            scitoken_destroy(scitoken);
+            scitoken_key_destroy(dummy_key);
+            return 1;
+        }
     }
     scitoken_destroy(scitoken);
+    if (dummy_key != nullptr) {
+        scitoken_key_destroy(dummy_key);
+    }
     std::cout << "Token deserialization successful." << std::endl;
 
     return 0;

--- a/src/verify.cpp
+++ b/src/verify.cpp
@@ -126,8 +126,7 @@ int main(int argc, char *const *argv) {
     SciToken scitoken = nullptr;
     SciTokenKey dummy_key = nullptr;
     if (g_profile.empty()) {
-        if (scitoken_deserialize(token.c_str(), &scitoken, nullptr,
-                                 &err_msg)) {
+        if (scitoken_deserialize(token.c_str(), &scitoken, nullptr, &err_msg)) {
             std::cout << "Failed to deserialize a token: " << err_msg
                       << std::endl;
             free(err_msg);


### PR DESCRIPTION
Two small correctness cleanups:

## CMake declares C++11, the code is C++17

`target_compile_features(SciTokens PUBLIC cxx_std_11)` — but the sources use structured bindings (`json_to_claim_map` in `scitokens_internal.cpp`, C++17) and `std::make_unique` (C++14). The project only compiles because modern compilers default to `gnu++17`; on a toolchain where the compile feature actually pins `-std=c++11`, the build fails. Declare `cxx_std_17` to match reality (CMake minimum here is 3.10, which supports it).

## `scitokens-verify --profile` was parsed but ignored

The tool documents `-p | --profile   Profile to enforce (wlcg, scitokens1, scitokens2, atjwt)` and stores the value — then never uses it: every token was accepted under COMPAT rules regardless. Wire it up via `scitoken_set_deserialize_profile` + `scitoken_deserialize_v2`, with an error for unknown profile names.

## Testing

- Full `make` (library, CLI tools, tests) and `ctest` unit/env_config/monitoring suites pass.
- `scitokens-verify -p bogus` now reports `unknown token profile`; valid profile names flow through deserialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)